### PR TITLE
asm: Use bool/uint8 as arguments instead of uint64s

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -40,4 +40,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.34
+          version: v1.36

--- a/curve/window.go
+++ b/curve/window.go
@@ -38,11 +38,11 @@ type projectiveNielsPointLookupTable [8]projectiveNielsPoint
 func (tbl *projectiveNielsPointLookupTable) lookup(x int8) projectiveNielsPoint {
 	// Compute xabs = |x|
 	xmask := x >> 7
-	xabs := (x + xmask) ^ xmask
+	xabs := uint8((x + xmask) ^ xmask)
 
 	// Set t = 0 * P = identity
 	var t projectiveNielsPoint
-	lookupProjectiveNiels(tbl, &t, uint64(xabs))
+	lookupProjectiveNiels(tbl, &t, xabs)
 	// Now t == |x| * P.
 
 	negMask := int(byte(xmask & 1))
@@ -81,11 +81,11 @@ type packedAffineNielsPointLookupTable [8][96]byte
 func (tbl *packedAffineNielsPointLookupTable) lookup(x int8) affineNielsPoint {
 	// Compute xabs = |x|
 	xmask := x >> 7
-	xabs := (x + xmask) ^ xmask
+	xabs := uint8((x + xmask) ^ xmask)
 
 	// Set t = 0 * P = identity
 	var tPacked [96]byte
-	lookupAffineNiels(tbl, &tPacked, uint64(xabs))
+	lookupAffineNiels(tbl, &tPacked, xabs)
 	// Now t == |x| * P.
 
 	// Unpack t.

--- a/curve/window_amd64.go
+++ b/curve/window_amd64.go
@@ -32,7 +32,7 @@
 package curve
 
 //go:noescape
-func lookupProjectiveNiels(table *projectiveNielsPointLookupTable, out *projectiveNielsPoint, xabs uint64)
+func lookupProjectiveNiels(table *projectiveNielsPointLookupTable, out *projectiveNielsPoint, xabs uint8)
 
 //go:noescape
-func lookupAffineNiels(table *packedAffineNielsPointLookupTable, out *[96]byte, xabs uint64)
+func lookupAffineNiels(table *packedAffineNielsPointLookupTable, out *[96]byte, xabs uint8)

--- a/curve/window_amd64.s
+++ b/curve/window_amd64.s
@@ -39,21 +39,21 @@
 // Additionally this version opts to use a loop, instead of unrolling
 // one, for better maintainability.
 
-// func lookupAffineNiels(table *packedAffineNielsPointLookupTable, out *byte, xabs uint64)
-TEXT ·lookupAffineNiels(SB), NOSPLIT|NOFRAME, $0-24
+// func lookupAffineNiels(table *packedAffineNielsPointLookupTable, out *byte, xabs uint8)
+TEXT ·lookupAffineNiels(SB), NOSPLIT|NOFRAME, $0-17
 	MOVQ table+0(FP), R14
 	MOVQ out+8(FP), R15
 
 	// y_plus_x, y_minus_x, xy2d
-	MOVQ   xabs+16(FP), AX
-	MOVD   AX, X14
-	PSHUFD $0x00, X14, X14
-	PXOR   X0, X0
-	PXOR   X1, X1
-	PXOR   X2, X2
-	PXOR   X3, X3
-	PXOR   X4, X4
-	PXOR   X5, X5
+	MOVBQZX xabs+16(FP), AX
+	MOVD    AX, X14
+	PSHUFD  $0x00, X14, X14
+	PXOR    X0, X0
+	PXOR    X1, X1
+	PXOR    X2, X2
+	PXOR    X3, X3
+	PXOR    X4, X4
+	PXOR    X5, X5
 
 	// 0
 	MOVQ    $0, AX
@@ -106,25 +106,25 @@ aniels_lookup_loop:
 
 	RET
 
-// func lookupProjectiveNiels(table, out *projectiveNielsPoint, xabs uint64)
-TEXT ·lookupProjectiveNiels(SB), NOSPLIT|NOFRAME, $0-24
+// func lookupProjectiveNiels(table, out *projectiveNielsPoint, xabs int8)
+TEXT ·lookupProjectiveNiels(SB), NOSPLIT|NOFRAME, $0-17
 	MOVQ table+0(FP), R14
 	MOVQ out+8(FP), R15
 
 	// Y_plus_X, Y_minus_X, Z, T2d
-	MOVQ   xabs+16(FP), AX
-	MOVD   AX, X14
-	PSHUFD $0x00, X14, X14
-	PXOR   X0, X0
-	PXOR   X1, X1
-	PXOR   X2, X2
-	PXOR   X3, X3
-	PXOR   X4, X4
-	PXOR   X5, X5
-	PXOR   X6, X6
-	PXOR   X7, X7
-	PXOR   X8, X8
-	PXOR   X9, X9
+	MOVBQZX xabs+16(FP), AX
+	MOVD    AX, X14
+	PSHUFD  $0x00, X14, X14
+	PXOR    X0, X0
+	PXOR    X1, X1
+	PXOR    X2, X2
+	PXOR    X3, X3
+	PXOR    X4, X4
+	PXOR    X5, X5
+	PXOR    X6, X6
+	PXOR    X7, X7
+	PXOR    X8, X8
+	PXOR    X9, X9
 
 	// 0
 	MOVQ       $0, AX

--- a/curve/window_generic.go
+++ b/curve/window_generic.go
@@ -33,7 +33,7 @@ package curve
 
 import "github.com/oasisprotocol/curve25519-voi/internal/subtle"
 
-func lookupProjectiveNiels(table *projectiveNielsPointLookupTable, out *projectiveNielsPoint, xabs uint64) {
+func lookupProjectiveNiels(table *projectiveNielsPointLookupTable, out *projectiveNielsPoint, xabs uint8) {
 	out.identity()
 	for j := 1; j < 9; j++ {
 		// Copy `points[j-1] == j*P` onto `t` in constant time if `|x| == j`.
@@ -42,7 +42,7 @@ func lookupProjectiveNiels(table *projectiveNielsPointLookupTable, out *projecti
 	}
 }
 
-func lookupAffineNiels(table *packedAffineNielsPointLookupTable, out *[96]byte, xabs uint64) {
+func lookupAffineNiels(table *packedAffineNielsPointLookupTable, out *[96]byte, xabs uint8) {
 	*out = identityAffineNielsPacked
 	for j := 1; j < 9; j++ {
 		// Copy `points[j-1] == j*P` onto `t` in constant time if `|x| == j`.

--- a/internal/field/field_u64_amd64.go
+++ b/internal/field/field_u64_amd64.go
@@ -33,13 +33,13 @@ package field
 
 import "golang.org/x/sys/cpu"
 
-var useBMI2 uint64
+var useBMI2 bool
 
 //go:noescape
-func feMul_AMD64(out, a, b *FieldElement, useBMI2 uint64)
+func feMul_AMD64(out, a, b *FieldElement, useBMI2 bool)
 
 //go:noescape
-func fePow2k_AMD64(out *FieldElement, k uint, useBMI2 uint64)
+func fePow2k_AMD64(out *FieldElement, k uint, useBMI2 bool)
 
 func feMul(out, a, b *FieldElement) {
 	feMul_AMD64(out, a, b, useBMI2)
@@ -50,7 +50,5 @@ func fePow2k(out *FieldElement, k uint) {
 }
 
 func init() {
-	if cpu.Initialized && cpu.X86.HasBMI2 {
-		useBMI2 = 1
-	}
+	useBMI2 = cpu.Initialized && cpu.X86.HasBMI2
 }

--- a/internal/field/field_u64_amd64.s
+++ b/internal/field/field_u64_amd64.s
@@ -61,20 +61,20 @@
 	ADDQ   DX, SI                \ // r00 += (r40 >> 51) *19
 	ANDQ   AX, R14               \ // r40 &= mask51
 
-// func feMul_AMD64(out, a, b *FieldElement, useBMI2 uint64)
+// func feMul_AMD64(out, a, b *FieldElement, useBMI2 bool)
 //
 // WARNING: You probably not have a CPU without BMI2.  If you edit this
 // routine in a meaningful way, the non-BMI2 case needs to be manually
 // tested by editing field_u64_amd64.go.
-TEXT ·feMul_AMD64(SB), NOSPLIT|NOFRAME, $0-32
+TEXT ·feMul_AMD64(SB), NOSPLIT|NOFRAME, $0-25
 	MOVQ a+8(FP), BX
 	MOVQ b+16(FP), CX
 
 	// Pick the appropriate implementation, based on if the caller thinks
 	// BMI2 is supported or not.
-	MOVQ  useBMI2+24(FP), DX
-	TESTQ DX, DX
-	JZ    mul_vanilla
+	MOVBQZX useBMI2+24(FP), DX
+	TESTQ   DX, DX
+	JZ      mul_vanilla
 
 	//
 	// This codepath uses BMI2 to shave off a number of instructions,
@@ -346,7 +346,7 @@ mul_reduce:
 	MOVQ R14, 32(DI)
 	RET
 
-// func fePow2k_AMD64(out *FieldElement, k uint64, useBMI2 uint64)
+// func fePow2k_AMD64(out *FieldElement, k uint64, useBMI2 bool)
 //
 // Note: This is changed from squaring to support any power-of-two greater
 // than zero, and to write the output out in-place.
@@ -354,15 +354,15 @@ mul_reduce:
 // WARNING: You probably not have a CPU without BMI2.  If you edit this
 // routine in a meaningful way, the non-BMI2 case needs to be manually
 // tested by editing field_u64_amd64.go.
-TEXT ·fePow2k_AMD64(SB), NOSPLIT|NOFRAME, $0-24
+TEXT ·fePow2k_AMD64(SB), NOSPLIT|NOFRAME, $0-17
 	MOVQ out+0(FP), BX
 	MOVQ k+8(FP), CX
 
 	// Pick the appropriate implementation, based on if the caller thinks
 	// BMI2 is supported or not.
-	MOVQ  useBMI2+16(FP), DX
-	TESTQ DX, DX
-	JZ    pow2k_loop_vanilla
+	MOVBQZX useBMI2+16(FP), DX
+	TESTQ   DX, DX
+	JZ      pow2k_loop_vanilla
 
 	// This codepath uses BMI2 to shave off a number of instructions,
 	// for a slight performance gain.  While it would be ideal to have


### PR DESCRIPTION
There isn't much practical difference, but this is more accurate.