### PR TITLE
primitives/ed25519: Compare compressed points for cofactorless verify

### DIFF
--- a/primitives/ed25519/batch_verify.go
+++ b/primitives/ed25519/batch_verify.go
@@ -160,7 +160,7 @@ func VerifyBatch(rand io.Reader, publicKeys []PublicKey, messages, sigs [][]byte
 
 		switch vOpts.CofactorlessVerify {
 		case true:
-			valid[i] = R.Equal(Rs[i]) == 1
+			valid[i] = pointsEqualCompressed(&R, Rs[i])
 		case false:
 			var rDiff curve.EdwardsPoint
 			rDiff.Sub(&R, Rs[i])

--- a/primitives/ed25519/ed25519.go
+++ b/primitives/ed25519/ed25519.go
@@ -494,7 +494,7 @@ func verifyWithOptionsNoPanic(publicKey PublicKey, message, sig []byte, opts *Op
 	// For the purpose of compatibility, support the old way of doing
 	// things, though this is now considered unwise.
 	if vOpts.CofactorlessVerify {
-		return checkR.Equal(&R) == 1, nil
+		return pointsEqualCompressed(&R, &checkR), nil
 	}
 
 	// Check that [8]R == [8](SB - H(R,A,m)A)).  Note that this actually
@@ -611,4 +611,12 @@ func scMinimal(scalar []byte) bool {
 	}
 
 	return true
+}
+
+func pointsEqualCompressed(a, b *curve.EdwardsPoint) bool {
+	var aCompressed, bCompressed curve.CompressedEdwardsY
+	aCompressed.FromEdwardsPoint(a)
+	bCompressed.FromEdwardsPoint(b)
+
+	return aCompressed.Equal(&bCompressed) == 1
 }


### PR DESCRIPTION
The fast way of doing things will break if enough of the coordinates are 0.