### PR TITLE
primitives/ed25519: Avoid leaking the SHA512 object

### DIFF
--- a/primitives/ed25519/batch_verify.go
+++ b/primitives/ed25519/batch_verify.go
@@ -120,7 +120,9 @@ func VerifyBatch(rand io.Reader, publicKeys []PublicKey, messages, sigs [][]byte
 			continue
 		}
 
-		writeDom2(h, f, context)
+		if dom2 := makeDom2(f, context); dom2 != nil {
+			_, _ = h.Write(dom2)
+		}
 		_, _ = h.Write(sigs[i][:32])
 		_, _ = h.Write(publicKeys[i][:])
 		_, _ = h.Write(messages[i])


### PR DESCRIPTION
This makes Go 1.16 not allocate the SHA512 object on the heap.  Prior
versions will, but that is unavoidable due to the hash.Hash interface
and lack of devirtualization.