### PR TITLE
primitives/ed25519: Misc fixes

### DIFF
--- a/primitives/ed25519/ed25519.go
+++ b/primitives/ed25519/ed25519.go
@@ -112,6 +112,19 @@ var (
 		Verify: VerifyOptionsDefault,
 	}
 
+	// order is the order of Curve25519 in little-endian form.
+	order = func() [4]uint64 {
+		var orderBytes [scalar.ScalarSize]byte
+		_ = scalar.BASEPOINT_ORDER.ToBytes(orderBytes[:])
+
+		var ret [4]uint64
+		for i := range ret {
+			ret[i] = binary.LittleEndian.Uint64(orderBytes[i*8 : (i+1)*8])
+		}
+
+		return ret
+	}()
+
 	_ crypto.Signer = (PrivateKey)(nil)
 )
 
@@ -612,9 +625,6 @@ func makeDom2(f dom2Flag, c []byte) []byte {
 
 	return b
 }
-
-// order is the order of Curve25519 in little-endian form.
-var order = [4]uint64{0x5812631a5cf5d3ed, 0x14def9dea2f79cd6, 0, 0x1000000000000000}
 
 // scMinimal returns true if the given scalar is less than the order of the
 // curve.

--- a/primitives/ed25519/ed25519_test.go
+++ b/primitives/ed25519/ed25519_test.go
@@ -260,6 +260,14 @@ func testGolden(t *testing.T) {
 }
 
 func testMalleability(t *testing.T) {
+	// At this point I could have just left this hardcoded as in the
+	// Go standard library, but parsing out BASEPOINT_ORDER is probably
+	// better.
+	expectedOrder := [4]uint64{0x5812631a5cf5d3ed, 0x14def9dea2f79cd6, 0, 0x1000000000000000}
+	if order != expectedOrder {
+		t.Fatalf("invalid deserialized BASEPOINT_ORDER: Got %v", order)
+	}
+
 	// https://tools.ietf.org/html/rfc8032#section-5.1.7 adds an additional test
 	// that s be in [0, order). This prevents someone from adding a multiple of
 	// order to s and obtaining a second valid signature for the same message.


### PR DESCRIPTION
 * Don't bother reducing `a` when signing
 * Don't hardcode BASEPOINT_ORDER in uint64 form