### PR TITLE
curve: Use SSE2 for the affine niels lookup table

### DIFF
--- a/curve/constants_test.go
+++ b/curve/constants_test.go
@@ -52,8 +52,6 @@ func testConstantsBShl128(t *testing.T) {
 	var p EdwardsPoint
 	p.mulByPow2(ED25519_BASEPOINT_POINT, 128)
 
-	t.Logf("p: %v", p)
-
 	if p.Equal(constB_SHL_128) != 1 {
 		t.Fatalf("B_SHL_128 != 2^128 B (Got: %v)", constB_SHL_128)
 	}

--- a/curve/window.go
+++ b/curve/window.go
@@ -106,7 +106,7 @@ func (tbl *affineNielsPointLookupTable) Basepoint() *EdwardsPoint {
 	return &ep
 }
 
-func lookupAffineNielsGeneric(table *affineNielsPointLookupTable, out *affineNielsPoint, xabs uint8) {
+func lookupAffineNielsGeneric(table *affineNielsPointLookupTable, out *affineNielsPoint, xabs uint8) { //nolint:unused,deadcode
 	out.Identity()
 	for j := 1; j < 9; j++ {
 		// Copy `points[j-1] == j*P` onto `t` in constant time if `|x| == j`.

--- a/curve/window_amd64.go
+++ b/curve/window_amd64.go
@@ -32,19 +32,7 @@
 package curve
 
 //go:noescape
-func lookupAffineNiels_AVX2(table *affineNielsPointLookupTable, out *affineNielsPoint, xabs uint8)
+func lookupAffineNiels(table *affineNielsPointLookupTable, out *affineNielsPoint, xabs uint8)
 
 //go:noescape
 func lookupCached(table *cachedPointLookupTable, out *cachedPoint, xabs uint8)
-
-func lookupAffineNiels(table *affineNielsPointLookupTable, out *affineNielsPoint, xabs uint8) {
-	// For the purposes of this routine, supportsVectorizedEdwards
-	// is just used as a "Does the system support AVX2" flag, and
-	// nothing else.
-	switch supportsVectorizedEdwards {
-	case true:
-		lookupAffineNiels_AVX2(table, out, xabs)
-	case false:
-		lookupAffineNielsGeneric(table, out, xabs)
-	}
-}

--- a/curve/window_amd64.s
+++ b/curve/window_amd64.s
@@ -60,68 +60,101 @@ DATA ·cached_id_2_4<>+0x18(SB)/4, $0
 DATA ·cached_id_2_4<>+0x1c(SB)/4, $33554431
 GLOBL ·cached_id_2_4<>(SB), (NOPTR+RODATA), $32
 
-// func lookupAffineNiels_AVX2(table *affineNielsPointLookupTable, out *affineNielsPoint, xabs uint8)
-TEXT ·lookupAffineNiels_AVX2(SB), NOSPLIT|NOFRAME, $0-17
+// func lookupAffineNiels(table *affineNielsPointLookupTable, out *affineNielsPoint, xabs uint8)
+TEXT ·lookupAffineNiels(SB), NOSPLIT|NOFRAME, $0-17
 	MOVQ table+0(FP), R14
 	MOVQ out+8(FP), R15
 
-	// This is moderately annoying due to having 5x3 64-bit elements, which
-	// does not nicely fit into 256-bit registers.  This is handled by
-	// duplicating one element in 2 ymm registers, since doing so keeps
-	// the rest of the code straight forward.
+	// This is moderately annoying due to having 5x3 64-bit elements,
+	// which does not nicely fit into vector registers.  This is
+	// handled by duplicating one element in 2 registers, since
+	// doing so keeps the rest of the code straight forward.
 	//
-	// ymm0 = y_plus_x_0,  y_plus_x_1,  y_plus_x_2,  y_plus_x_3
-	// ymm1 = y_plus_x_4,  y_minus_x_0, y_minus_x_1, y_minus_x_2
-	// ymm2 = y_minus_x_3, y_minus_x_4, xy2d_0,      xy2d_1
-	// ymm3 = xy2d_1 (*),  xy2d_2,      xy2d_3,      xy2d_4
+	// xmm0 = y_plus_x_0,  y_plus_x_1
+	// xmm1 = y_plus_x_2,  y_plus_x_3
+	// xmm2 = y_plus_x_4,  y_minus_x_0
+	// xmm3 = y_minus_x_1, y_minus_x_2
+	// xmm4 = y_minus_x_3, y_minus_x_4
+	// xmm5 = xy2d_0,      xy2d_1
+	// xmm6 = xy2d_1 (*),  xy2d_2
+	// xmm7 = xy2d_3,      xy2d_4
+	//
+	// Note: Before I get tempted to rewrite this to use AVX2 again,
+	// I will to take a moment to remind myself that the AVX2 backend
+	// does not use this table.
 
-	MOVBQZX      xabs+16(FP), AX
-	VMOVD        AX, X14
-	VPBROADCASTD X14, Y14
-	VPXOR        Y0, Y0, Y0
-	VPXOR        Y1, Y1, Y1
-	VPXOR        Y2, Y2, Y2
-	VPXOR        Y3, Y3, Y3
+	MOVBQZX xabs+16(FP), AX
+	MOVD    AX, X14
+	PSHUFD  $0x00, X14, X14
+	PXOR    X0, X0
+	PXOR    X1, X1
+	PXOR    X2, X2
+	PXOR    X3, X3
+	PXOR    X4, X4
+	PXOR    X5, X5
+	PXOR    X6, X6
+	PXOR    X7, X7
 
 	// 0
-	MOVD         $0, AX
-	VMOVD        AX, X15
-	VPBROADCASTD X15, Y15
-	VPCMPEQD     Y14, Y15, Y15
-	MOVQ         $1, AX
-	VMOVQ        AX, X4
-	VPINSRQ      $1, AX, X0, X5
-	VPAND        Y15, Y4, Y4
-	VPAND        Y15, Y5, Y5
-	VPOR         Y0, Y4, Y0
-	VPOR         Y1, Y5, Y1
+	MOVQ       $0, AX
+	MOVD       AX, X15
+	PSHUFD     $0x00, X15, X15
+	PCMPEQL    X14, X15
+	MOVQ       $1, AX
+	MOVQ       AX, X8          // xmm8 = uint64{1, 0} (y_plus_x_0, y_plus_x_1)
+	PXOR       X9, X9
+	PUNPCKLQDQ X8, X9          // xmm9 = uint64{0, 1} (y_plus_x_4, y_minus_x_0)
+	PAND       X15, X8
+	PAND       X15, X9
+	POR        X8, X0
+	POR        X9, X2
 
 	// 1 .. 8
 	MOVQ $1, AX
 
 affine_lookup_loop:
-	VMOVD        AX, X15
-	VPBROADCASTD X15, Y15
-	VPCMPEQD     Y14, Y15, Y15
-	VPAND        0(R14), Y15, Y4
-	VPAND        32(R14), Y15, Y5
-	VPAND        64(R14), Y15, Y6
-	VPAND        88(R14), Y15, Y7
-	VPOR         Y0, Y4, Y0
-	VPOR         Y1, Y5, Y1
-	VPOR         Y2, Y6, Y2
-	VPOR         Y3, Y7, Y3
-	ADDQ         $120, R14
-	INCQ         AX
-	CMPQ         AX, $8
-	JLE          affine_lookup_loop
+	MOVD    AX, X15
+	PSHUFD  $0x00, X15, X15
+	PCMPEQL X14, X15
+	MOVOU   0(R14), X8
+	MOVOU   16(R14), X9
+	MOVOU   32(R14), X10
+	MOVOU   48(R14), X11
+	PAND    X15, X8
+	PAND    X15, X9
+	PAND    X15, X10
+	PAND    X15, X11
+	POR     X8, X0
+	POR     X9, X1
+	POR     X10, X2
+	POR     X11, X3
+	MOVOU   64(R14), X8
+	MOVOU   80(R14), X9
+	MOVOU   88(R14), X10
+	MOVOU   104(R14), X11
+	PAND    X15, X8
+	PAND    X15, X9
+	PAND    X15, X10
+	PAND    X15, X11
+	POR     X8, X4
+	POR     X9, X5
+	POR     X10, X6
+	POR     X11, X7
+	ADDQ    $120, R14
+	INCQ    AX
+	CMPQ    AX, $8
+	JLE     affine_lookup_loop
 
-	VMOVDQU Y0, 0(R15)
-	VMOVDQU Y1, 32(R15)
-	VMOVDQU Y2, 64(R15)
-	VMOVDQU Y3, 88(R15)
+	// Write out the result.
+	MOVOU X0, 0(R15)
+	MOVOU X1, 16(R15)
+	MOVOU X2, 32(R15)
+	MOVOU X3, 48(R15)
+	MOVOU X4, 64(R15)
+	MOVOU X5, 80(R15)
+	MOVOU X6, 88(R15)
+	MOVOU X7, 104(R15)
 
-	VZEROUPPER
 	RET
 
 // func lookupCached(table, out *cachedPoint, xabs int8)
@@ -130,7 +163,7 @@ TEXT ·lookupCached(SB), NOSPLIT|NOFRAME, $0-17
 	MOVQ out+8(FP), R15
 
 	MOVBQZX      xabs+16(FP), AX
-	VMOVD        AX, X14
+	VMOVQ        AX, X14
 	VPBROADCASTD X14, Y14
 	VPXOR        Y0, Y0, Y0
 	VPXOR        Y1, Y1, Y1
@@ -139,8 +172,8 @@ TEXT ·lookupCached(SB), NOSPLIT|NOFRAME, $0-17
 	VPXOR        Y4, Y4, Y4
 
 	// 0
-	MOVD         $0, AX
-	VMOVD        AX, X15
+	MOVQ         $0, AX
+	VMOVQ        AX, X15
 	VPBROADCASTD X15, Y15
 	VPCMPEQD     Y14, Y15, Y15
 	VMOVDQA      ·cached_id_0<>(SB), Y5
@@ -163,7 +196,7 @@ TEXT ·lookupCached(SB), NOSPLIT|NOFRAME, $0-17
 	MOVQ $1, AX
 
 cached_lookup_loop:
-	VMOVD        AX, X15
+	VMOVQ        AX, X15
 	VPBROADCASTD X15, Y15
 	VPCMPEQD     Y14, Y15, Y15
 	VPAND        0(R14), Y15, Y5


### PR DESCRIPTION
While AVX2 is great and all, when AVX2 is available, the affine niels
table isn't used, so having an AVX2 lookup routine is pointless since it
will never be called.

I am an idiot.