### PR TITLE
primitives: Implement sr25519

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,7 @@ Copyright (c) 2016-2019 isis agora lovecruft. All rights reserved.
 Copyright (c) 2016-2019 Henry de Valence. All rights reserved.
 Copyright (c) 2016, 2019 The Go Authors. All rights reserved.
 Copyright (c) 2017, 2019 George Tankersley. All rights reserved.
+Copyright (c) 2019-2020 Web 3 Foundation. All rights reserved.
 Copyright (c) 2020 Jack Grigg. All rights reserved.
 Copyright (c) 2020-2021 Oasis Labs Inc. All rights reserved.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 Copyright (c) 2016-2019 isis agora lovecruft. All rights reserved.
 Copyright (c) 2016-2019 Henry de Valence. All rights reserved.
 Copyright (c) 2016, 2019 The Go Authors. All rights reserved.
-Copyright (c) 2017 George Tankersley. All rights reserved.
+Copyright (c) 2017, 2019 George Tankersley. All rights reserved.
 Copyright (c) 2020 Jack Grigg. All rights reserved.
 Copyright (c) 2020-2021 Oasis Labs Inc. All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@
 > frankly.  There must still be some residual damage-repair capability.
 > We Demarchists build for posterity, you know.
 
-This package aims to provide a modern X25519/Ed25519 implementation
-for Go, mostly derived from curve25519-dalek.  The primary motivation
-is to hopefully provide a worthy alternative to the current state of
-available Go implementations, which is best described as "a gigantic
-mess of ref10 and donna ports".  The irony of the previous statement
-in the light of curve25519-dalek's lineage does not escape this author.
+This package aims to provide a modern X25519/Ed25519/sr25519
+implementation for Go, mostly derived from curve25519-dalek.  The
+primary motivation is to hopefully provide a worthy alternative to
+the current state of available Go implementations, which is best
+described as "a gigantic mess of ref10 and donna ports".  The irony
+of the previous statement in the light of curve25519-dalek's lineage
+does not escape this author.
 
 #### WARNING
 
@@ -20,6 +21,7 @@ in the light of curve25519-dalek's lineage does not escape this author.
  * curve: A mid-level API in the spirit of curve25519-dalek.
  * primitives/x25519: A X25519 implementation like `x/crypto/curve25519`.
  * primitives/ed25519: A Ed25519 implementation like `crypto/ed25519`.
+ * primitives/sr25519: A sr25519 implementation like `https://github.com/w3f/schnorrkel`.
 
 #### Ed25519 verification semantics
 

--- a/curve/scalar/sc_minimal.go
+++ b/curve/scalar/sc_minimal.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2016 The Go Authors. All rights reserved.
+// Copyright (c) 2019-2021 Oasis Labs Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//   * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package scalar
+
+import "encoding/binary"
+
+// order is the order of Curve25519 in little-endian form.
+var order = func() [4]uint64 {
+	var orderBytes [ScalarSize]byte
+	_ = BASEPOINT_ORDER.ToBytes(orderBytes[:])
+
+	var ret [4]uint64
+	for i := range ret {
+		ret[i] = binary.LittleEndian.Uint64(orderBytes[i*8 : (i+1)*8])
+	}
+
+	return ret
+}()
+
+// ScMinimal returns true if the given byte-encoded scalar is less than
+// the order of the curve, in variable-time.
+//
+// This method is intended for verification applications, and is
+// significantly faster than deserializing the scalar and calling
+// IsCanonical.
+func ScMinimal(scalar []byte) bool {
+	if scalar[31]&240 == 0 {
+		// 4 most significant bits unset, succeed fast
+		return true
+	}
+	if scalar[31]&224 != 0 {
+		// Any of the 3 most significant bits set, fail fast
+		return false
+	}
+
+	// 4th most significant bit set (unlikely), actually check vs order
+	for i := 3; ; i-- {
+		v := binary.LittleEndian.Uint64(scalar[i*8:])
+		if v > order[i] {
+			return false
+		} else if v < order[i] {
+			break
+		} else if i == 0 {
+			return false
+		}
+	}
+
+	return true
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/oasisprotocol/curve25519-voi
 go 1.16
 
 require (
+	github.com/mimoo/StrobeGo v0.0.0-20181016162300-f8f6d4d2b643 // indirect
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/mimoo/StrobeGo v0.0.0-20181016162300-f8f6d4d2b643 h1:hLDRPB66XQT/8+wG9WsDpiCvZf1yKO7sz7scAjSlBa0=
+github.com/mimoo/StrobeGo v0.0.0-20181016162300-f8f6d4d2b643/go.mod h1:43+3pMjjKimDBf5Kr4ZFNGbLql1zKkbImw+fZbw3geM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad h1:DN0cp81fZ3njFcrLCytUHRSUkqBjfTo4Tx9RJTWs0EY=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=

--- a/internal/merlin/merlin.go
+++ b/internal/merlin/merlin.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2019 George Tankersley
+// Copyright (c) 2019 Henry de Valence
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package merlin
+
+import (
+	"encoding/binary"
+
+	"github.com/mimoo/StrobeGo/strobe"
+)
+
+const (
+	merlinProtocolLabel  = "Merlin v1.0"
+	domainSeparatorLabel = "dom-sep"
+)
+
+type Transcript struct {
+	s strobe.Strobe
+}
+
+func NewTranscript(appLabel string) *Transcript {
+	t := Transcript{
+		s: strobe.InitStrobe(merlinProtocolLabel, 128),
+	}
+
+	t.AppendMessage([]byte(domainSeparatorLabel), []byte(appLabel))
+	return &t
+}
+
+// Append adds the message to the transcript with the supplied label.
+func (t *Transcript) AppendMessage(label, message []byte) {
+	// AD[label || le32(len(message))](message)
+
+	sizeBuffer := make([]byte, 4)
+	binary.LittleEndian.PutUint32(sizeBuffer[0:], uint32(len(message)))
+
+	// The StrobeGo API does not support continuation operations,
+	// so we have to pass the label and length as a single buffer.
+	// Otherwise it will record two meta-AD operations instead of one.
+	labelSize := append(label, sizeBuffer...)
+	t.s.AD(true, labelSize)
+
+	t.s.AD(false, message)
+}
+
+// ExtractBytes returns a buffer filled with the verifier's challenge bytes.
+// The label parameter is metadata about the challenge, and is also appended to
+// the transcript. See the Transcript Protocols section of the Merlin website
+// for details on labels.
+func (t *Transcript) ExtractBytes(label []byte, outLen int) []byte {
+	sizeBuffer := make([]byte, 4)
+	binary.LittleEndian.PutUint32(sizeBuffer[0:], uint32(outLen))
+
+	// The StrobeGo API does not support continuation operations,
+	// so we have to pass the label and length as a single buffer.
+	// Otherwise it will record two meta-AD operations instead of one.
+	labelSize := append(label, sizeBuffer...)
+	t.s.AD(true, labelSize)
+
+	// A PRF call directly to the output buffer (in the style of an append API)
+	// would be better, but our underlying STROBE library forces an allocation
+	// here.
+	outBytes := t.s.PRF(outLen)
+	return outBytes
+}

--- a/internal/merlin/merlin.go
+++ b/internal/merlin/merlin.go
@@ -1,5 +1,6 @@
 // Copyright (c) 2019 George Tankersley
 // Copyright (c) 2019 Henry de Valence
+// Copyright (c) 2021 Oasis Labs Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -52,6 +53,13 @@ func NewTranscript(appLabel string) *Transcript {
 
 	t.AppendMessage([]byte(domainSeparatorLabel), []byte(appLabel))
 	return &t
+}
+
+// Clone returns a deep-copy of the transcript.
+func (t *Transcript) Clone() *Transcript {
+	return &Transcript{
+		s: *t.s.Clone(),
+	}
 }
 
 // Append adds the message to the transcript with the supplied label.

--- a/internal/merlin/merlin_test.go
+++ b/internal/merlin/merlin_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2019 George Tankersley
+// Copyright (c) 2019 Henry de Valence
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package merlin
+
+import (
+	"fmt"
+	"testing"
+)
+
+// Initialize STROBE-128(4d65726c696e2076312e30)   # b"Merlin v1.0"
+// meta-AD : 646f6d2d736570 || LE32(13)    # b"dom-sep"
+// AD : 746573742070726f746f636f6c    # b"test protocol"
+// meta-AD : 736f6d65206c6162656c || LE32(9)       # b"some label"
+// AD : 736f6d652064617461    # b"some data"
+// meta-AD : 6368616c6c656e6765 || LE32(32)        # b"challenge"
+// PRF: d5a21972d0d5fe320c0d263fac7fffb8145aa640af6e9bca177c03c7efcf0615
+// test transcript::tests::equivalence_simple ... ok
+
+func TestSimpleTranscript(t *testing.T) {
+	mt := NewTranscript("test protocol")
+	mt.AppendMessage([]byte("some label"), []byte("some data"))
+
+	cBytes := mt.ExtractBytes([]byte("challenge"), 32)
+	cHex := fmt.Sprintf("%x", cBytes)
+	expectedHex := "d5a21972d0d5fe320c0d263fac7fffb8145aa640af6e9bca177c03c7efcf0615"
+
+	if cHex != expectedHex {
+		t.Errorf("\nGot : %s\nWant: %s", cHex, expectedHex)
+	}
+}
+
+func TestComplexTranscript(t *testing.T) {
+	tr := NewTranscript("test protocol")
+	tr.AppendMessage([]byte("step1"), []byte("some data"))
+
+	data := make([]byte, 1024)
+	for i := range data {
+		data[i] = 99
+	}
+
+	var chlBytes []byte
+	for i := 0; i < 32; i++ {
+		chlBytes = tr.ExtractBytes([]byte("challenge"), 32)
+		tr.AppendMessage([]byte("bigdata"), data)
+		tr.AppendMessage([]byte("challengedata"), chlBytes)
+	}
+
+	expectedChlHex := "a8c933f54fae76e3f9bea93648c1308e7dfa2152dd51674ff3ca438351cf003c"
+	chlHex := fmt.Sprintf("%x", chlBytes)
+
+	if chlHex != expectedChlHex {
+		t.Errorf("\nGot : %s\nWant: %s", chlHex, expectedChlHex)
+	}
+}

--- a/internal/merlin/merlin_test.go
+++ b/internal/merlin/merlin_test.go
@@ -1,5 +1,6 @@
 // Copyright (c) 2019 George Tankersley
 // Copyright (c) 2019 Henry de Valence
+// Copyright (c) 2021 Oasis Labs Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -78,5 +79,35 @@ func TestComplexTranscript(t *testing.T) {
 
 	if chlHex != expectedChlHex {
 		t.Errorf("\nGot : %s\nWant: %s", chlHex, expectedChlHex)
+	}
+}
+
+func TestClone(t *testing.T) {
+	mt := NewTranscript("test protocol")
+	mt.AppendMessage([]byte("some label"), []byte("some data"))
+
+	mtCopy, mtCopy2 := mt.Clone(), mt.Clone()
+
+	// Ensure that mtCopy matches what we would get from mt.
+	cBytes := mtCopy.ExtractBytes([]byte("challenge"), 32)
+	cHex := fmt.Sprintf("%x", cBytes)
+	expectedHex := "d5a21972d0d5fe320c0d263fac7fffb8145aa640af6e9bca177c03c7efcf0615"
+	if cHex != expectedHex {
+		t.Errorf("\nmtCopy Got : %s\nWant: %s", cHex, expectedHex)
+	}
+
+	// Append more to mtCopy2, ensure that it is different.
+	mtCopy2.AppendMessage([]byte("someother label"), []byte("someother data"))
+	cBytes = mtCopy2.ExtractBytes([]byte("challenge"), 32)
+	cHex = fmt.Sprintf("%x", cBytes)
+	if cHex == expectedHex {
+		t.Errorf("\nmtCopy2 Got : %s\nWant: %s", cHex, expectedHex)
+	}
+
+	// Finally, extract from mt.
+	cBytes = mt.ExtractBytes([]byte("challenge"), 32)
+	cHex = fmt.Sprintf("%x", cBytes)
+	if cHex != expectedHex {
+		t.Errorf("\nmtCopy Got : %s\nWant: %s", cHex, expectedHex)
 	}
 }

--- a/internal/zeroreader/zeroreader.go
+++ b/internal/zeroreader/zeroreader.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2016 The Go Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//   * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Package zeroreader provides a io.Reader that returns all zero output.
+package zeroreader
+
+// ZeroReader implements an io.Reader that returns all zero output.
+type ZeroReader struct{}
+
+func (ZeroReader) Read(buf []byte) (int, error) {
+	for i := range buf {
+		buf[i] = 0
+	}
+	return len(buf), nil
+}

--- a/primitives/ed25519/ed25519_test.go
+++ b/primitives/ed25519/ed25519_test.go
@@ -53,7 +53,6 @@ func TestStdLib(t *testing.T) {
 	t.Run("CryptoSigner/Hashed", testCryptoSignerHashed)
 	t.Run("Equal", testEqual)
 	t.Run("Golden", testGolden)
-	t.Run("ScMinimal", testScMinimal)
 	t.Run("Malleability", testMalleability)
 }
 
@@ -250,36 +249,6 @@ func testGolden(t *testing.T) {
 
 	if err := scanner.Err(); err != nil {
 		t.Fatalf("error reading test data: %s", err)
-	}
-}
-
-func testScMinimal(t *testing.T) {
-	// At this point I could have just left this hardcoded as in the
-	// Go standard library, but parsing out BASEPOINT_ORDER is probably
-	// better.
-	expectedOrder := [4]uint64{0x5812631a5cf5d3ed, 0x14def9dea2f79cd6, 0, 0x1000000000000000}
-	if order != expectedOrder {
-		t.Fatalf("invalid deserialized BASEPOINT_ORDER: Got %v", order)
-	}
-
-	// External review caught an early version of the fail-fast check
-	// that had a bug due to an incorrect constant.  Run through a few
-	// test cases to make sure that everything is ok.
-	for _, v := range []struct {
-		scalarHex string
-		expected  bool
-	}{
-		{"0000000000000000000000000000000000000000000000000000000000000010", true},  // From review
-		{"ddd3f55c1a631258d69cf7a2def9de1400000000000000000000000000000010", true},  // Order - 1
-		{"edd3f55c1a631258d69cf7a2def9de1400000000000000000000000000000010", false}, // Order
-		{"0000000000000000000000000000000000000000000000000000000000000020", false},
-		{"0000000000000000000000000000000000000000000000000000000000000040", false},
-		{"0000000000000000000000000000000000000000000000000000000000000080", false},
-	} {
-		b := mustUnhex(v.scalarHex)
-		if scMinimal(b) != v.expected {
-			t.Fatalf("scMinimal(%s) != %v", v.scalarHex, v.expected)
-		}
 	}
 }
 

--- a/primitives/ed25519/ed25519_test.go
+++ b/primitives/ed25519/ed25519_test.go
@@ -41,16 +41,9 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/oasisprotocol/curve25519-voi/internal/zeroreader"
 )
-
-type zeroReader struct{}
-
-func (zeroReader) Read(buf []byte) (int, error) {
-	for i := range buf {
-		buf[i] = 0
-	}
-	return len(buf), nil
-}
 
 func TestStdLib(t *testing.T) {
 	// Tests mostly shamelessly stolen from the standard library.
@@ -65,7 +58,7 @@ func TestStdLib(t *testing.T) {
 }
 
 func testSignVerify(t *testing.T) {
-	var zero zeroReader
+	var zero zeroreader.ZeroReader
 	public, private, _ := GenerateKey(zero)
 
 	message := []byte("test message")
@@ -104,7 +97,7 @@ func testSignVerifyHashed(t *testing.T) {
 }
 
 func testCryptoSigner(t *testing.T) {
-	var zero zeroReader
+	var zero zeroreader.ZeroReader
 	public, private, _ := GenerateKey(zero)
 
 	signer := crypto.Signer(private)
@@ -141,7 +134,7 @@ func testCryptoSigner(t *testing.T) {
 }
 
 func testCryptoSignerHashed(t *testing.T) {
-	var zero zeroReader
+	var zero zeroreader.ZeroReader
 	public, private, _ := GenerateKey(zero)
 
 	signer := crypto.Signer(private)
@@ -315,7 +308,7 @@ func testMalleability(t *testing.T) {
 }
 
 func BenchmarkGenerateKey(b *testing.B) {
-	var zero zeroReader
+	var zero zeroreader.ZeroReader
 	b.Run("voi", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
@@ -351,7 +344,7 @@ func BenchmarkNewKeyFromSeed(b *testing.B) {
 }
 
 func BenchmarkSigning(b *testing.B) {
-	var zero zeroReader
+	var zero zeroreader.ZeroReader
 	_, priv, err := GenerateKey(zero)
 	if err != nil {
 		b.Fatal(err)
@@ -373,7 +366,7 @@ func BenchmarkSigning(b *testing.B) {
 }
 
 func BenchmarkVerification(b *testing.B) {
-	var zero zeroReader
+	var zero zeroreader.ZeroReader
 	pub, priv, err := GenerateKey(zero)
 	if err != nil {
 		b.Fatal(err)
@@ -413,7 +406,7 @@ func BenchmarkVerification(b *testing.B) {
 }
 
 func BenchmarkExpanded(b *testing.B) {
-	var zero zeroReader
+	var zero zeroreader.ZeroReader
 	pub, priv, err := GenerateKey(zero)
 	if err != nil {
 		b.Fatal(err)

--- a/primitives/sr25519/batch_verify.go
+++ b/primitives/sr25519/batch_verify.go
@@ -1,5 +1,6 @@
+// Copyright (c) 2019 Web 3 Foundation. All rights reserved.
 // Copyright (c) 2020 Henry de Valence. All rights reserved.
-// Copyright (c) 2020-2021 Oasis Labs Inc. All rights reserved.
+// Copyright (c) 2021 Oasis Labs Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
@@ -28,139 +29,81 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-package ed25519
+package sr25519
 
 import (
 	cryptorand "crypto/rand"
-	"crypto/sha512"
 	"io"
 
 	"github.com/oasisprotocol/curve25519-voi/curve"
 	"github.com/oasisprotocol/curve25519-voi/curve/scalar"
+	"github.com/oasisprotocol/curve25519-voi/internal/merlin"
+	"github.com/oasisprotocol/curve25519-voi/internal/zeroreader"
 )
 
-// BatchVerifier accumulates batch entries with Add, before performing
-// batch verifcation with Verify.
 type BatchVerifier struct {
 	entries []entry
 
-	anyInvalid      bool
-	anyCofactorless bool
+	anyInvalid bool
 }
 
 type entry struct {
-	signature []byte
-
-	// Note: Unlike ed25519consensus, this stores R, and A, S, and hram
-	// in the entry, so that it is possible to implement a more
-	// useful verification API (information about which signature(s)
-	// are invalid is wanted a lot of the time), without having to
-	// redo a non-trivial amount of computation.
-	//
-	// Additionally A is stored as a expanded public key to allow
-	// for the code to be reused for the expanded case, and to
-	// accelerate the serial verification in the event of a batch
-	// verification failure.
-	R    curve.EdwardsPoint
-	A    *ExpandedPublicKey
+	// Store r, s, A, and hram in the entry, so that it is possible
+	// to implement a more useful verfication API (information about
+	// which signature(s) are invalid is wanted a lot of the time),
+	// without having to redo a non-trivial amount of computation.
+	R    curve.RistrettoPoint
 	S    scalar.Scalar
+	A    curve.RistrettoPoint
 	hram scalar.Scalar
 
-	wantCofactorless bool
-	canBeValid       bool
+	witnessA     curve.CompressedRistretto
+	witnessR     curve.CompressedRistretto
+	witnessBytes [16]byte
+
+	canBeValid bool
 }
 
-func (e *entry) doInit(publicKey *ExpandedPublicKey, message, sig []byte, opts *Options) {
+func (e *entry) doInit(pk *PublicKey, transcript *SigningTranscript, signature *Signature) {
 	// Until everything has been deserialized correctly, assume the
 	// entry is totally invalid.
 	e.canBeValid = false
 
-	fBase, context, err := opts.verify()
-	if err != nil {
-		return
-	}
-	vOpts := opts.Verify
-	if vOpts == nil {
-		vOpts = VerifyOptionsDefault
-	}
-
-	// This is nonsensical (as in, cofactorless batch-verification
-	// is flat out incorrect), but the API allows for requesting it.
-	if e.wantCofactorless = vOpts.CofactorlessVerify; e.wantCofactorless {
-		e.signature = sig
-	}
-
-	// Validate A, Deserialize R and S.
-	if e.A = publicKey; e.A == nil {
-		return
-	}
-	if ok := vOpts.checkExpandedPublicKey(publicKey); !ok {
-		return
-	}
-	if ok := vOpts.unpackSignature(sig, &e.R, &e.S); !ok {
+	// Check for a uninitialized public key/signature.
+	if pk.point == nil || signature.s == nil {
 		return
 	}
 
-	// Calculate H(R,A,m).
-	var (
-		f dom2Flag
-
-		hash [64]byte
-		h    = sha512.New()
-	)
-
-	if f, err = checkHash(fBase, message, opts.HashFunc()); err != nil {
+	// Signature deserialization checks that the signature is well-formed,
+	// *except* for doing point-decompression on R.
+	if _, err := e.R.SetCompressed(&signature.rCompressed); err != nil {
 		return
 	}
+	e.S.Set(signature.s)
+	e.A.Set(pk.point)
 
-	if dom2 := makeDom2(f, context); dom2 != nil {
-		_, _ = h.Write(dom2)
-	}
-	_, _ = h.Write(sig[:32])
-	_, _ = h.Write(publicKey.compressed[:])
-	_, _ = h.Write(message)
-	h.Sum(hash[:0])
-	if _, err = e.hram.SetBytesModOrderWide(hash[:]); err != nil {
-		return
-	}
+	// Calculate the challenge scalar (hram aka k).
+	e.hram.Set(deriveVerifyChallengeScalar(pk, transcript, signature))
 
-	// Ok, R, A, S, and hram can at least be deserialized/computed,
+	// Calculate the transcript's delinearization component.
+	if err := transcript.witnessBytes([]byte{}, e.witnessBytes[:], nil, zeroreader.ZeroReader{}); err != nil {
+		panic("sr25519: failed to generate transcript delinearization value: " + err.Error())
+	}
+	e.witnessA = pk.compressed
+	e.witnessR = signature.rCompressed
+
+	// Ok, so the signature and public key appear to be well-formed,
 	// so it is possible for the entry to be valid.
 	e.canBeValid = true
 }
 
-// Add adds a (public key, message, sig) triple to the current batch.
-func (v *BatchVerifier) Add(publicKey PublicKey, message, sig []byte) {
-	v.AddWithOptions(publicKey, message, sig, optionsDefault)
-}
-
-// AddWithOptions adds a (public key, message, sig, opts) quad to the
-// current batch.
-//
-// WARNING: This routine will panic if opts is nil.
-func (v *BatchVerifier) AddWithOptions(publicKey PublicKey, message, sig []byte, opts *Options) {
-	// The error is explicitly discarded as doInit will do the
-	// right thing if the public key is nil.
-	precomputedPublicKey, _ := NewExpandedPublicKey(publicKey)
-	v.AddExpandedWithOptions(precomputedPublicKey, message, sig, opts)
-}
-
-// AddExpanded adds a (expanded public key, message, sig) triple to the
-// current batch.
-func (v *BatchVerifier) AddExpanded(publicKey *ExpandedPublicKey, message, sig []byte) {
-	v.AddExpandedWithOptions(publicKey, message, sig, optionsDefault)
-}
-
-// AddExpandedWithOptions adds a (precomputed public key, message, sig,
-// opts) quad to the current batch.
-//
-// WARNING: This routine will panic if opts is nil.
-func (v *BatchVerifier) AddExpandedWithOptions(publicKey *ExpandedPublicKey, message, sig []byte, opts *Options) {
+// Add adds a (public key, transcript, signature) triple to the current
+// batch.
+func (v *BatchVerifier) Add(pk *PublicKey, transcript *SigningTranscript, signature *Signature) {
 	var e entry
 
-	e.doInit(publicKey, message, sig, opts)
+	e.doInit(pk, transcript, signature)
 	v.anyInvalid = v.anyInvalid || !e.canBeValid
-	v.anyCofactorless = v.anyCofactorless || e.wantCofactorless
 	v.entries = append(v.entries, e)
 }
 
@@ -170,17 +113,13 @@ func (v *BatchVerifier) AddExpandedWithOptions(publicKey *ExpandedPublicKey, mes
 //
 // If a failure arises it is unknown which entry failed, the caller must
 // verify each entry individually.
-//
-// Calling Verify on an empty batch, or a batch containing any entries that
-// specifiy cofactor-less verification will return false.
 func (v *BatchVerifier) VerifyBatchOnly(rand io.Reader) bool {
 	if rand == nil {
 		rand = cryptorand.Reader
 	}
 
 	vl := len(v.entries)
-	numDynamic := 1 + vl
-	numTerms := numDynamic + vl
+	numTerms := 1 + vl + vl
 
 	// Handle some early aborts.
 	switch {
@@ -188,12 +127,8 @@ func (v *BatchVerifier) VerifyBatchOnly(rand io.Reader) bool {
 		// Abort early on an empty batch, which probably indicates a bug
 		return false
 	case v.anyInvalid:
-		// Abort early if any of the `Add`/`AddWithOptions` calls failed
-		// to fully execute, since at least one entry is invalid.
-		return false
-	case v.anyCofactorless:
-		// Abort early if any of the entries requested cofactor-less
-		// verification, since that flat out doesn't work.
+		// Abort early if any of the `Add` calls failed to fully execute,
+		// since at least one entry is invalid.
 		return false
 	}
 
@@ -217,20 +152,43 @@ func (v *BatchVerifier) VerifyBatchOnly(rand io.Reader) bool {
 	Bcoeff := scalars[0]
 	Rcoeffs := scalars[1 : 1+vl]
 	Acoeffs := scalars[1+vl:]
-	dynamicScalars := scalars[0 : 1+vl] // Bcoeff | Rcoeffs
 
 	// No need to allocate a backing-store since B, Rs and As already
 	// have concrete instances.
-	dynamicPoints := make([]*curve.EdwardsPoint, numDynamic) // B | Rs
-	staticPoints := make([]*curve.ExpandedEdwardsPoint, vl)  // As
+	points := make([]*curve.RistrettoPoint, numTerms) // B | Rs | As
+	Rs := points[1 : 1+vl]
+	As := points[1+vl:]
 
-	dynamicPoints[0] = curve.ED25519_BASEPOINT_POINT // B
+	// Accumulate public keys, signatures, and transcripts for
+	// delineariazation.
+	//
+	// Note: Iterating over v repeatedly is kind of gross, but it's
+	// what the Rust implementation does.  I'm not convinced that
+	// it matters, but for now do the same thing.
+	zs_t := &SigningTranscript{
+		t: merlin.NewTranscript("V-RNG"),
+	}
+	for i := range v.entries {
+		zs_t.commitPoint([]byte{}, &v.entries[i].witnessA)
+	}
+	for i := range v.entries {
+		zs_t.commitPoint([]byte{}, &v.entries[i].witnessR)
+	}
+	for i := range v.entries {
+		zs_t.commitBytes([]byte{}, v.entries[i].witnessBytes[:])
+	}
+	zs_rng, err := zs_t.witnessRng([]byte{}, nil, rand)
+	if err != nil {
+		panic("sr25519: failed to instantiate delinearization rng: " + err.Error())
+	}
+
+	points[0] = curve.RISTRETTO_BASEPOINT_POINT // B
 	var randomBytes [scalar.ScalarSize]byte
 	for i := range v.entries {
 		// Avoid range copying each v.entries[i] literal.
 		entry := &v.entries[i]
-		dynamicPoints[1+i] = &entry.R
-		staticPoints[i] = &entry.A.negA
+		Rs[i] = &entry.R
+		As[i] = &entry.A
 
 		// An inquisitive reader would ask why this doesn't just do
 		// `z.SetRandom(rand)`, and instead, opts to duplicate the code.
@@ -243,30 +201,22 @@ func (v *BatchVerifier) VerifyBatchOnly(rand io.Reader) bool {
 		// Additionally, we want z_i to be 128-bit scalars, so only
 		// sampling 128-bits, and skipping the reduction is more
 		// performant.
-		if _, err := io.ReadFull(rand, randomBytes[:scalar.ScalarSize/2]); err != nil {
-			panic("ed25519: failed to generate batch verification scalar: " + err.Error())
+		if _, err = io.ReadFull(zs_rng, randomBytes[:scalar.ScalarSize/2]); err != nil {
+			panic("sr25519: failed to generate batch verification scalar: " + err.Error())
 		}
-		if _, err := Rcoeffs[i].SetBits(randomBytes[:]); err != nil {
-			panic("ed25519: failed to deserialize batch verification scalar: " + err.Error())
+		if _, err = Rcoeffs[i].SetBits(randomBytes[:]); err != nil {
+			panic("sr25519: failed to deserialize batch verification scalar: " + err.Error())
 		}
 
 		var sz scalar.Scalar
 		Bcoeff.Add(Bcoeff, sz.Mul(Rcoeffs[i], &entry.S))
-
-		// The precomputation calculates multiples for -A_i, so
-		// this needs to calculate -[z_i * k_i] to fix the sign.
-		//
-		// While this does incur some extra overhead, it is
-		// negligible, and saves having to calculate and store
-		// a separate table.
 		Acoeffs[i].Mul(Rcoeffs[i], &entry.hram)
-		Acoeffs[i].Neg(Acoeffs[i])
 	}
 	Bcoeff.Neg(Bcoeff) // this term is subtracted in the summation
 
-	// Check the cofactored batch verification equation.
-	var shouldBeId curve.EdwardsPoint
-	return shouldBeId.ExpandedMultiscalarMulVartime(Acoeffs, staticPoints, dynamicScalars, dynamicPoints).IsSmallOrder()
+	// Check the batch verification equation.
+	var shouldBeId curve.RistrettoPoint
+	return shouldBeId.MultiscalarMulVartime(scalars, points).IsIdentity()
 }
 
 // Verify checks all entries in the current batch using entropy from rand,
@@ -292,20 +242,16 @@ func (v *BatchVerifier) Verify(rand io.Reader) (bool, []bool) {
 		valid[i] = v.entries[i].canBeValid
 	}
 
-	// If batch verification is possible, do the batch verification.
-	if !v.anyInvalid && !v.anyCofactorless {
+	if !v.anyInvalid {
 		if v.VerifyBatchOnly(rand) {
 			// Fast-path, the entire batch is valid.
 			return true, valid
 		}
 	}
 
-	// Slow-path, one or more signatures is either invalid, or needs
-	// cofactor-less verification.
-	//
-	// Note: In the case of the latter it is still possible for the
-	// entire batch to be valid, but it is incorrect to trust the
-	// batch verification results.
+	// Slow-path, one or more signatures is invalid with overwhelming
+	// probability.  The results of serial verification is held to be
+	// correct.
 	allValid := !v.anyInvalid
 	for i := range v.entries {
 		// If the entry is known to be invalid, skip the serial
@@ -315,24 +261,20 @@ func (v *BatchVerifier) Verify(rand io.Reader) (bool, []bool) {
 		}
 
 		entry := &v.entries[i]
-		negA := &entry.A.negA
 
-		switch entry.wantCofactorless {
-		case true:
-			var R curve.EdwardsPoint
-			R.ExpandedDoubleScalarMulBasepointVartime(&entry.hram, negA, &entry.S)
-			valid[i] = cofactorlessVerify(&R, entry.signature)
-		case false:
-			var rDiff curve.EdwardsPoint
-			valid[i] = rDiff.ExpandedTripleScalarMulBasepointVartime(&entry.hram, negA, &entry.S, &entry.R).IsSmallOrder()
-		}
+		var (
+			negA  curve.RistrettoPoint
+			rDiff curve.RistrettoPoint
+		)
+		negA.Neg(&entry.A)
+		valid[i] = rDiff.TripleScalarMulBasepointVartime(&entry.hram, &negA, &entry.S, &entry.R).IsIdentity()
 		allValid = allValid && valid[i]
 	}
 
 	return allValid, valid
 }
 
-// NewBatchVerfier creates an empty BatchVerifier.
+// NewBatchVerifier creates an empty BatchVerifier.
 func NewBatchVerifier() *BatchVerifier {
 	return &BatchVerifier{}
 }

--- a/primitives/sr25519/batch_verify_test.go
+++ b/primitives/sr25519/batch_verify_test.go
@@ -1,0 +1,242 @@
+// Copyright (c) 2021 Oasis Labs Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package sr25519
+
+import (
+	//"crypto"
+	"fmt"
+	"testing"
+)
+
+var benchBatchSizes = []int{1, 2, 4, 8, 16, 32, 64, 128, 256, 384, 512, 768, 1024}
+
+type batchTest int
+
+const (
+	batchNoErrors batchTest = iota
+	batchBadTranscript
+	batchBadSignature
+	batchBadPublicKey
+
+	testBatchSize = 38
+)
+
+type batchVerifierTestCase struct {
+	n          string
+	tst        batchTest
+	culpritIdx int
+	details    string
+}
+
+var batchTestCases = []*batchVerifierTestCase{
+	{
+		"Verify",
+		batchNoErrors,
+		-1,
+		"failed batch verification",
+	},
+	{
+		"FailsOnBadTranscript",
+		batchBadTranscript,
+		0,
+		"batch verification should fail due to bad transcript",
+	},
+	{
+		"FailsOnBadSignature",
+		batchBadSignature,
+		1,
+		"batch verification should fail due to bad signature",
+	},
+	{
+		"FailsOnBadPublicKey",
+		batchBadPublicKey,
+		2,
+		"batch verification should fail due to bad public key",
+	},
+}
+
+func (tc *batchVerifierTestCase) makeVerifier(t *testing.T) *BatchVerifier {
+	const n = 38
+
+	v := NewBatchVerifier()
+	kps := make([]*KeyPair, 0, n)
+	pubs := make([]*PublicKey, 0, n)
+	msgs := make([][]byte, 0, n)
+
+	goodContext := NewSigningContext([]byte("test-batch-verify:good"))
+	badContext := NewSigningContext([]byte("test-batch-verify:bad"))
+
+	for i := 0; i < testBatchSize; i++ {
+		kp, err := GenerateKeyPair(nil)
+		if err != nil {
+			t.Fatalf("failed to GenerateKeyPair: %v", err)
+		}
+
+		var msg []byte
+		if i%2 == 0 {
+			msg = []byte("easter")
+		} else {
+			msg = []byte("egg")
+		}
+
+		msgs = append(msgs, msg)
+		kps = append(kps, kp)
+		pubs = append(pubs, kp.PublicKey())
+	}
+
+	// If the test case calls for it, introduce errors in the batch.
+	culpritIdx := tc.culpritIdx
+	switch tc.tst {
+	case batchBadPublicKey:
+		for {
+			kp, err := GenerateKeyPair(nil)
+			if err != nil {
+				t.Fatalf("failed to GenerateKeyPair: %v", err)
+			}
+			pk := kp.PublicKey()
+			if !pk.Equal(pubs[0]) {
+				pubs[culpritIdx] = pk
+				break
+			}
+		}
+	}
+
+	sigs := make([]*Signature, 0, n)
+	transcripts := make([]*SigningTranscript, 0, n)
+
+	for i := range kps {
+		st := goodContext.NewTranscriptBytes(msgs[i])
+		sig, err := kps[i].Sign(nil, st)
+		if err != nil {
+			t.Fatalf("failed to Sign: %v", err)
+		}
+
+		transcripts = append(transcripts, st)
+		sigs = append(sigs, sig)
+	}
+
+	switch tc.tst {
+	case batchBadTranscript:
+		transcripts[culpritIdx] = badContext.NewTranscriptBytes(msgs[culpritIdx])
+	case batchBadSignature:
+		sigs[culpritIdx] = sigs[0]
+	}
+
+	// Build the batch.
+	for i := range pubs {
+		v.Add(pubs[i], transcripts[i], sigs[i])
+	}
+
+	return v
+}
+
+func (tc *batchVerifierTestCase) run(t *testing.T) {
+	v := tc.makeVerifier(t)
+	expectedBatchOk := tc.culpritIdx < 0
+	expectedVerifyOk := expectedBatchOk
+
+	// First test that the batch verify returns the expected
+	// result for the entire batch.
+	if v.VerifyBatchOnly(nil) != expectedBatchOk {
+		t.Error(tc.details)
+	}
+
+	// Then test the actually useful API.
+	allValid, valid := v.Verify(nil)
+	if allValid != expectedVerifyOk {
+		t.Errorf("Verify returned incorrect summary (Got: %v)", allValid)
+	}
+
+	// The ensure that the bit-vector contains the expected
+	// signature validity status.  tc.culpritIdx is the index
+	// of the malformed/invalid signature.
+	for i, sigValid := range valid {
+		expectedSigOk := i != tc.culpritIdx
+		if sigValid != expectedSigOk {
+			t.Errorf("bit-vector %d incorrect (Got: %v)", i, sigValid)
+		}
+	}
+}
+
+func TestBatchVerifier(t *testing.T) {
+	t.Run("sr25519", func(t *testing.T) {
+		for _, tc := range batchTestCases {
+			t.Run(tc.n, func(t *testing.T) {
+				tc.run(t)
+			})
+		}
+	})
+
+	t.Run("EmptyBatchFails", func(t *testing.T) {
+		v := NewBatchVerifier()
+
+		if v.VerifyBatchOnly(nil) {
+			t.Error("batch verification should fail on an empty batch")
+		}
+	})
+}
+
+func BenchmarkVerifyBatchOnly(b *testing.B) {
+	for _, n := range benchBatchSizes {
+		doBenchVerifyBatchOnly(b, n)
+	}
+}
+
+func doBenchVerifyBatchOnly(b *testing.B, n int) {
+	kp, err := GenerateKeyPair(nil)
+	if err != nil {
+		b.Fatalf("failed to GenerateKeyPair: %v", err)
+	}
+	pk := kp.PublicKey()
+
+	msg := []byte("BatchVerifyTest")
+
+	sc := NewSigningContext([]byte("benchmark-batch-verify"))
+	st := sc.NewTranscriptBytes(msg)
+	sig, err := kp.Sign(nil, st)
+	if err != nil {
+		b.Fatalf("failed to sign: %v", err)
+	}
+
+	b.Run(fmt.Sprint(n), func(b *testing.B) {
+		b.ReportAllocs()
+
+		for i := 0; i < b.N; i++ {
+			v := NewBatchVerifier()
+			for j := 0; j < n; j++ {
+				v.Add(pk, st, sig)
+			}
+
+			if !v.VerifyBatchOnly(nil) {
+				b.Fatal("signature set failed batch verification")
+			}
+		}
+	})
+}

--- a/primitives/sr25519/context.go
+++ b/primitives/sr25519/context.go
@@ -1,0 +1,189 @@
+// Copyright (c) 2019 Web 3 Foundation. All rights reserved.
+// Copyright (c) 2021 Oasis Labs Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package sr25519
+
+import (
+	"fmt"
+	"hash"
+	"io"
+	"math"
+
+	"golang.org/x/crypto/blake2b"
+
+	"github.com/oasisprotocol/curve25519-voi/curve"
+	"github.com/oasisprotocol/curve25519-voi/curve/scalar"
+	"github.com/oasisprotocol/curve25519-voi/internal/merlin"
+)
+
+// SigningContext is a Schnoor signing context.
+type SigningContext struct {
+	t *merlin.Transcript
+}
+
+// NewSigningContext initializes a new signing context from a static byte
+// string that identifies the signer's role in the larger protocol.
+func NewSigningContext(context []byte) *SigningContext {
+	t := merlin.NewTranscript("SigningContext")
+	t.AppendMessage([]byte{}, context)
+	return &SigningContext{
+		t: t,
+	}
+}
+
+// NewTranscriptBytes initializes a new signing transcript on a message
+// provided as a byte array.  If the length of b will overflow a 32-bit
+// unsigned integer, this method will panic.
+//
+// Note: This method should not be used for large messages as it calls
+// merlin directly, and merlin is designed for domain separation, not
+// performance.
+func (sc *SigningContext) NewTranscriptBytes(b []byte) *SigningTranscript {
+	t := sc.t.Clone()
+	t.AppendMessage([]byte("sign-bytes"), b)
+	return &SigningTranscript{
+		t: t,
+	}
+}
+
+// NewTranscriptHash initializes a new signing transcript on a message
+// provided as a hash.Hash, with a digest size of either 256-bits or
+// 512-bits.  If the digest size is neither 256-bits nor 512-bits, this
+// method will panic.
+func (sc *SigningContext) NewTranscriptHash(h hash.Hash) *SigningTranscript {
+	var hLabel []byte
+	switch h.Size() {
+	case 32:
+		hLabel = []byte("sign-256")
+	case 64:
+		hLabel = []byte("sign-512")
+	default:
+		panic("sr25519: invalid hash digest size")
+	}
+	prehash := h.Sum(nil)
+
+	t := sc.t.Clone()
+	t.AppendMessage(hLabel, prehash)
+	return &SigningTranscript{
+		t: t,
+	}
+}
+
+// NewTranscriptXOF initializes a new signing transcript on a message
+// provided as a hash function that is an XOF instance.
+//
+// Note: Despite the blake2b.XOF input, this interface is also implemented
+// by the applicable hash functiopns provided by x/crypto/sha3 and
+// x/crypto/blake2s.
+func (sc *SigningContext) NewTranscriptXOF(xof blake2b.XOF) *SigningTranscript {
+	h := xof.Clone()
+	prehash := make([]byte, 32)
+	if _, err := io.ReadFull(h, prehash); err != nil {
+		panic("sr25519: failed to read XOF output: " + err.Error())
+	}
+
+	t := sc.t.Clone()
+	t.AppendMessage([]byte("sign-XoF"), prehash)
+	return &SigningTranscript{
+		t: t,
+	}
+}
+
+// SigningTranscript is a Schnoor signing transcript.
+type SigningTranscript struct {
+	t *merlin.Transcript
+}
+
+func (st *SigningTranscript) clone() *SigningTranscript {
+	return &SigningTranscript{
+		t: st.t.Clone(),
+	}
+}
+
+func (st *SigningTranscript) commitBytes(label, b []byte) {
+	if lLen := uint64(len(label)); lLen > math.MaxUint32 {
+		panic("sr25519: label length exceeds merlin limits")
+	}
+	if bLen := uint64(len(b)); bLen > math.MaxUint32 {
+		panic("sr25519: b length exceeds merlin limits")
+	}
+
+	st.t.AppendMessage(label, b)
+}
+
+func (st *SigningTranscript) protoName(label []byte) {
+	st.commitBytes([]byte("proto-name"), label)
+}
+
+func (st *SigningTranscript) commitPoint(label []byte, compressed *curve.CompressedRistretto) {
+	st.commitBytes(label, compressed[:])
+}
+
+func (st *SigningTranscript) challengeBytes(label []byte, outLen int) []byte {
+	return st.t.ExtractBytes(label, outLen)
+}
+
+func (st *SigningTranscript) challengeScalar(label []byte) *scalar.Scalar {
+	buf := st.challengeBytes(label, scalar.ScalarWideSize)
+	s, err := scalar.NewFromBytesModOrderWide(buf)
+	if err != nil {
+		panic("sr25519: scalar.NewFromBytesModOrderWide: " + err.Error())
+	}
+	return s
+}
+
+func (st *SigningTranscript) witnessScalar(label []byte, nonceSeeds [][]byte, rng io.Reader) (*scalar.Scalar, error) {
+	rng, err := st.witnessRng(label, nonceSeeds, rng)
+	if err != nil {
+		return nil, fmt.Errorf("sr25519: failed to construct transcript rng: %w", err)
+	}
+	return scalar.New().SetRandom(rng)
+}
+
+func (st *SigningTranscript) witnessBytes(label, dest []byte, nonceSeeds [][]byte, rng io.Reader) error {
+	rng, err := st.witnessRng(label, nonceSeeds, rng)
+	if err != nil {
+		return fmt.Errorf("sr25519: failed to construct transcript rng: %w", err)
+	}
+
+	if _, err := rng.Read(dest); err != nil {
+		return fmt.Errorf("sr25519: failed to read from transcript rng: %w", err)
+	}
+
+	return nil
+}
+
+func (st *SigningTranscript) witnessRng(label []byte, nonceSeeds [][]byte, rng io.Reader) (io.Reader, error) {
+	br := st.t.BuildRng()
+	for _, ns := range nonceSeeds {
+		br.RekeyWithWitnessBytes(label, ns)
+	}
+	return br.Finalize(rng)
+}

--- a/primitives/sr25519/doc.go
+++ b/primitives/sr25519/doc.go
@@ -1,0 +1,3 @@
+// Package sr25519 implements the sr25519 signature algorithm.  See
+// https://github.com/w3f/schnorrkel/.
+package sr25519

--- a/primitives/sr25519/keys.go
+++ b/primitives/sr25519/keys.go
@@ -1,0 +1,430 @@
+// Copyright (c) 2019 isis agora lovecruft. All rights reserved.
+// Copyright (c) 2019 Web 3 Foundation. All rights reserved.
+// Copyright (c) 2021 Oasis Labs Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package sr25519
+
+import (
+	"crypto/rand"
+	"crypto/sha512"
+	"crypto/subtle"
+	"fmt"
+	"io"
+
+	"github.com/oasisprotocol/curve25519-voi/curve"
+	"github.com/oasisprotocol/curve25519-voi/curve/scalar"
+	"github.com/oasisprotocol/curve25519-voi/internal/merlin"
+)
+
+const (
+	// MiniSecretKeySize is the size of a MiniSecretKey in bytes.
+	MiniSecretKeySize = 32
+
+	// SecretKeyScalarSize is the size of the scalar component of a
+	// SecretKey in bytes.
+	SecretKeyScalarSize = scalar.ScalarSize
+
+	// SecretKeyNonceSize is the size of the nonce component of a
+	// SecretKey in bytes.
+	SecretKeyNonceSize = 32
+
+	// SecretKeySize is the size of a SecretKey in bytes.
+	SecretKeySize = SecretKeyScalarSize + SecretKeyNonceSize
+
+	// PublicKeySize is the size of a PublicKey in bytes.
+	PublicKeySize = curve.CompressedPointSize
+
+	// KeyPairSize is the size of a KeyPair in bytes.
+	KeyPairSize = SecretKeySize + PublicKeySize
+)
+
+func scalarDivideByCofactor(b []byte) (*scalar.Scalar, error) {
+	var (
+		scalarBytes [scalar.ScalarSize]byte
+		low         byte
+	)
+	for i := scalar.ScalarSize - 1; i >= 0; i-- {
+		v := b[i]
+		r := v & 0b00000111 // save remainder
+		v = v >> 3          // divide by 8
+		scalarBytes[i] = v + low
+		low = r << 5
+	}
+
+	return scalar.NewFromBits(scalarBytes[:])
+}
+
+// MiniSecretKey is an EdDSA-like seed, from which the expanded secret
+// key is generated.
+type MiniSecretKey [MiniSecretKeySize]byte
+
+// MarshalBinary encodes a MiniSecretKey into binary form.
+func (msk *MiniSecretKey) MarshalBinary() ([]byte, error) {
+	return append([]byte{}, msk[:]...), nil
+}
+
+// UnmarshalBinary decodes a binary marshaled MiniSecretKey.
+func (msk *MiniSecretKey) UnmarshalBinary(data []byte) error {
+	if l := len(data); l != MiniSecretKeySize {
+		return fmt.Errorf("sr25519: bad MiniSecretKey size: %v", l)
+	}
+
+	copy(msk[:], data)
+
+	return nil
+}
+
+// Equal reports if msk and other have the same value.  This function
+// will execute in constant time.
+func (msk *MiniSecretKey) Equal(other *MiniSecretKey) bool {
+	return subtle.ConstantTimeCompare(msk[:], other[:]) == 1
+}
+
+// ExpandUniform expands a MiniSecretKey into a SecretKey using merlin.
+func (msk *MiniSecretKey) ExpandUniform() *SecretKey {
+	t := merlin.NewTranscript("ExpandSecretKeys")
+	t.AppendMessage([]byte("mini"), msk[:])
+
+	scalarBytes := t.ExtractBytes([]byte("sk"), 64)
+	keyScalar, err := scalar.NewFromBytesModOrderWide(scalarBytes)
+	if err != nil {
+		panic("sr25519: scalar.NewFromBytesModOrderWide: " + err.Error())
+	}
+
+	nonceBytes := t.ExtractBytes([]byte("no"), 32)
+
+	sk := &SecretKey{
+		key: keyScalar,
+	}
+	copy(sk.nonce[:], nonceBytes)
+
+	return sk
+}
+
+// ExpandEd25519 expands a MiniSecretKey into a SecretKey using
+// Ed25519-style bit clamping.
+//
+// Note: Unless there is a specific reason to do so (eg: compatibility),
+// the use of this method is discouraged.
+func (msk *MiniSecretKey) ExpandEd25519() *SecretKey {
+	digest := sha512.Sum512(msk[:])
+	digest[0] &= 248
+	digest[31] &= 63
+	digest[31] |= 64
+
+	keyScalar, err := scalarDivideByCofactor(digest[:32])
+	if err != nil {
+		panic("sr25519: failed to deserialize key scalar: " + err.Error())
+	}
+
+	sk := &SecretKey{
+		key: keyScalar,
+	}
+	copy(sk.nonce[:], digest[32:])
+
+	return sk
+}
+
+// NewMiniSecretKeyFromBytes constructs a MiniSecretKey from the byte
+// representation.
+func NewMiniSecretKeyFromBytes(b []byte) (*MiniSecretKey, error) {
+	var msk MiniSecretKey
+	if err := msk.UnmarshalBinary(b); err != nil {
+		return nil, err
+	}
+	return &msk, nil
+}
+
+// GenerateMiniSecretKey generates a MiniSecretKey using entropy from rng.
+// If rng is nil, crypto/rand.Reader will be used.
+func GenerateMiniSecretKey(rng io.Reader) (*MiniSecretKey, error) {
+	if rng == nil {
+		rng = rand.Reader
+	}
+
+	var msk MiniSecretKey
+	if _, err := io.ReadFull(rng, msk[:]); err != nil {
+		return nil, fmt.Errorf("sr25519: failed to read entropy: %w", err)
+	}
+
+	return &msk, nil
+}
+
+// SecretKey is an expanded secret key.
+type SecretKey struct {
+	key   *scalar.Scalar
+	nonce [SecretKeyNonceSize]byte
+}
+
+// MarshalBinary encodes a SecretKey into binary form.
+func (sk *SecretKey) MarshalBinary() ([]byte, error) {
+	b := make([]byte, SecretKeyScalarSize, SecretKeySize)
+
+	if sk.key != nil {
+		if err := sk.key.ToBytes(b[:SecretKeyScalarSize]); err != nil {
+			return nil, fmt.Errorf("sr25519: failed to serialize key scalar: %w", err)
+		}
+	}
+
+	b = append(b, sk.nonce[:]...)
+
+	return b, nil
+}
+
+// UnmarshalBinary decodes a binary marshaled SecretKey.
+func (sk *SecretKey) UnmarshalBinary(data []byte) error {
+	if l := len(data); l != SecretKeySize {
+		return fmt.Errorf("sr25519: bad SecretKey size: %v", l)
+	}
+
+	keyScalar, err := scalar.NewFromCanonicalBytes(data[:SecretKeyScalarSize])
+	if err != nil {
+		return fmt.Errorf("sr25519: failed to deserialize key scalar: %w", err)
+	}
+
+	sk.key = keyScalar
+	copy(sk.nonce[:], data[32:])
+
+	return nil
+}
+
+// PublicKey derives the public key corresponding to the SecretKey.
+func (sk *SecretKey) PublicKey() *PublicKey {
+	if sk.key == nil {
+		panic("sr25519: attempted to derive public key from uninitialized SecretKey")
+	}
+
+	var A curve.RistrettoPoint
+	A.MulBasepoint(curve.RISTRETTO_BASEPOINT_TABLE, sk.key)
+
+	return newPublicKeyFromPoint(&A)
+}
+
+// KeyPair returns the key pair corresponding to the SecretKey.
+func (sk *SecretKey) KeyPair() *KeyPair {
+	return &KeyPair{
+		sk: sk,
+		pk: sk.PublicKey(),
+	}
+}
+
+// Equal reports if sk and other have the same value, where equality checks
+// both the scalar and the nonce components.  This function will execute
+// in constant time.
+func (sk *SecretKey) Equal(other *SecretKey) bool {
+	cmp := sk.key.Equal(other.key)
+	cmp = cmp & subtle.ConstantTimeCompare(sk.nonce[:], other.nonce[:])
+	return cmp == 1
+}
+
+// NewSecretKeyFromBytes constructs a SecretKey from the byte representation.
+func NewSecretKeyFromBytes(b []byte) (*SecretKey, error) {
+	var sk SecretKey
+	if err := sk.UnmarshalBinary(b); err != nil {
+		return nil, err
+	}
+	return &sk, nil
+}
+
+// GenerateSecretKey generates a SecretKey using entropy from rng.
+// If rng is nil, crypto/rand.Reader will be used.
+func GenerateSecretKey(rng io.Reader) (*SecretKey, error) {
+	if rng == nil {
+		rng = rand.Reader
+	}
+
+	sk := &SecretKey{
+		key: scalar.New(),
+	}
+	if _, err := sk.key.SetRandom(rng); err != nil {
+		return nil, fmt.Errorf("sr25519: failed to generate random scalar: %w", err)
+	}
+
+	if _, err := io.ReadFull(rng, sk.nonce[:]); err != nil {
+		return nil, fmt.Errorf("sr25519: failed to generate random nonce: %w", err)
+	}
+
+	return sk, nil
+}
+
+// PublicKey is a public key.
+type PublicKey struct {
+	compressed curve.CompressedRistretto
+	point      *curve.RistrettoPoint
+}
+
+// MarshalBinary encodes a PublicKey into binary form.
+func (pk *PublicKey) MarshalBinary() ([]byte, error) {
+	switch pk.point {
+	case nil:
+		// Uninitialized, this could return an error, but an all 0
+		// CompressedRistretto is the identity element, so it is
+		// "fine".
+		return make([]byte, PublicKeySize), nil
+	default:
+		return append([]byte{}, pk.compressed[:]...), nil
+	}
+}
+
+// UnmarshalBinary decodes a binary marshaled PublicKey.
+func (pk *PublicKey) UnmarshalBinary(data []byte) error {
+	pk.compressed.Identity()
+	pk.point = nil
+
+	if l := len(data); l != PublicKeySize {
+		return fmt.Errorf("sr25519: bad PublicKey size: %v", l)
+	}
+
+	var compressedA curve.CompressedRistretto
+	if err := compressedA.UnmarshalBinary(data); err != nil {
+		return fmt.Errorf("sr25519: failed to deserialize public key: %w", err)
+	}
+
+	var A curve.RistrettoPoint
+	if _, err := A.SetCompressed(&compressedA); err != nil {
+		return fmt.Errorf("sr25519: failed to decompress public key: %w", err)
+	}
+
+	pk.compressed = compressedA
+	pk.point = &A
+
+	return nil
+}
+
+// Equal reports if pk and other have the same value.  This function will
+// execute in constant time.
+func (pk *PublicKey) Equal(other *PublicKey) bool {
+	return pk.compressed.Equal(&other.compressed) == 1
+}
+
+// NewPublicKeyFromBytes constructs a PublicKey from the byte representation.
+func NewPublicKeyFromBytes(b []byte) (*PublicKey, error) {
+	var pk PublicKey
+	if err := pk.UnmarshalBinary(b); err != nil {
+		return nil, err
+	}
+	return &pk, nil
+}
+
+func newPublicKeyFromPoint(point *curve.RistrettoPoint) *PublicKey {
+	var pk PublicKey
+	pk.compressed.SetRistrettoPoint(point)
+	pk.point = curve.NewRistrettoPoint().Set(point)
+
+	return &pk
+}
+
+// KeyPair encapsulates a SecretKey and PublicKey.
+type KeyPair struct {
+	sk *SecretKey
+	pk *PublicKey
+}
+
+// MarshalBinary encodes a KeyPair into binary form.
+func (kp *KeyPair) MarshalBinary() ([]byte, error) {
+	// Uninitialized keypair, assume the default value of the secret key.
+	if kp.sk == nil || kp.pk == nil {
+		return make([]byte, KeyPairSize), nil
+	}
+
+	skBytes, err := kp.sk.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+
+	pkBytes, err := kp.pk.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+
+	b := make([]byte, 0, KeyPairSize)
+	b = append(b, skBytes...)
+	b = append(b, pkBytes...)
+
+	return b, nil
+}
+
+// UnmarshalBinary decodes a binary marshaled KeyPair.
+func (kp *KeyPair) UnmarshalBinary(data []byte) error {
+	kp.sk = nil
+	kp.pk = nil
+
+	if l := len(data); l != KeyPairSize {
+		return fmt.Errorf("sr25519: bad KeyPair size: %v", l)
+	}
+
+	var sk SecretKey
+	if err := sk.UnmarshalBinary(data[:SecretKeySize]); err != nil {
+		return err
+	}
+
+	var pk PublicKey
+	if err := pk.UnmarshalBinary(data[SecretKeySize:]); err != nil {
+		return err
+	}
+
+	if !sk.PublicKey().Equal(&pk) {
+		return fmt.Errorf("sr25519: bad KeyPair, public key mismatch")
+	}
+
+	kp.sk = &sk
+	kp.pk = &pk
+
+	return nil
+}
+
+// SecretKey returns the secret key component of the KeyPair.
+func (kp *KeyPair) SecretKey() *SecretKey {
+	return kp.sk
+}
+
+// PublicKey returns the public key component of the KeyPair.
+func (kp *KeyPair) PublicKey() *PublicKey {
+	return kp.pk
+}
+
+// NewKeyPairFromBytes constructs a KeyPair from the byte representation.
+func NewKeyPairFromBytes(b []byte) (*KeyPair, error) {
+	var kp KeyPair
+	if err := kp.UnmarshalBinary(b); err != nil {
+		return nil, err
+	}
+	return &kp, nil
+}
+
+// GenerateKeyPair generates a KeyPair using entropy from rng.
+// If rng is nil, crypto/rand.Reader will be used.
+func GenerateKeyPair(rng io.Reader) (*KeyPair, error) {
+	sk, err := GenerateSecretKey(rng)
+	if err != nil {
+		return nil, err
+	}
+	return sk.KeyPair(), nil
+}

--- a/primitives/sr25519/keys_test.go
+++ b/primitives/sr25519/keys_test.go
@@ -1,0 +1,319 @@
+// Copyright (c) 2017-2020 isis agora lovecruft. All rights reserved.
+// Copyright (c) 2019-2020 Web 3 Foundation. All rights reserved.
+// Copyright (c) 2021 Oasis Labs Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package sr25519
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"testing"
+
+	"github.com/oasisprotocol/curve25519-voi/curve/scalar"
+)
+
+func isAllZeros(b []byte) bool {
+	for _, v := range b {
+		if v != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func TestScalarDivideByCofactor(t *testing.T) {
+	var b [scalar.ScalarSize]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		t.Fatalf("failed to read random scalar bytes: %v", err)
+	}
+
+	// Apply the "clamp", that always will be applied to the input
+	// to the routine we are testing.
+	b[0] &= 248
+	b[31] &= 63
+	b[31] |= 64
+
+	sExpected, err := scalar.NewFromBytesModOrder(b[:])
+	if err != nil {
+		t.Fatalf("failed to deserialize random scalar: %v", err)
+	}
+
+	s, err := scalarDivideByCofactor(b[:])
+	if err != nil {
+		t.Fatalf("failed to divide by cofactor: %v", err)
+	}
+
+	s.Mul(s, scalar.NewFromUint64(8)) // Multiply by 8
+
+	if sExpected.Equal(s) != 1 {
+		t.Fatalf("(b / 8) * 8 != b (Got %v expected %v)", s, sExpected)
+	}
+}
+
+func TestMiniSecretKey(t *testing.T) {
+	t.Run("s11n", func(t *testing.T) {
+		msk, err := GenerateMiniSecretKey(nil)
+		if err != nil {
+			t.Fatalf("GenerateMiniSecretKey: %v", err)
+		}
+
+		b, err := msk.MarshalBinary()
+		if err != nil {
+			t.Fatalf("msk.MarshalBinary: %v", err)
+		}
+
+		if !bytes.Equal(b, msk[:]) {
+			t.Fatalf("msk.MarshalBinary() != msk (Got %v, %v)", b, msk)
+		}
+
+		var msk2 MiniSecretKey
+		if err = msk2.UnmarshalBinary(b); err != nil {
+			t.Fatalf("msk2.UnmarshalBinary(b): %v", err)
+		}
+
+		if msk2 != *msk {
+			t.Fatalf("msk != msk2 (Got %v, %v)", *msk, msk2)
+		}
+	})
+	t.Run("ExpandUniform", func(t *testing.T) {
+		expected, err := hex.DecodeString("04f0557e7f35e00df0824f458868915368bd5e41fd91f85b177f5907383ac50bdd0660b091e0ec47ecaf1f6ce73e7168fef267770f5030d5c524a49615163471063b66cc8b77aa24f694d073ad72c21a9f296be0fd4ee953d8e58d5d627d435b")
+		if err != nil {
+			t.Fatalf("failed to deserialize expected hex: %v", err)
+		}
+		var kp KeyPair
+		if err := kp.UnmarshalBinary(expected); err != nil {
+			t.Fatalf("kp.UnmarshalBinary: %v", err)
+		}
+
+		var msk MiniSecretKey
+		sk := msk.ExpandUniform()
+
+		if !kp.SecretKey().Equal(sk) {
+			t.Fatalf("sk != expected (Got %v)", sk)
+		}
+		if pk := sk.PublicKey(); !kp.PublicKey().Equal(pk) {
+			t.Fatalf("sk.PublicKey() != expected (Got %v)", pk)
+		}
+	})
+	t.Run("ExpandEd25519", func(t *testing.T) {
+		expected, err := hex.DecodeString("caa835781b15c7706f65b71f7a58c807ab360faed6440fb23e0f4c52e930de0a0a6a85eaa642dac835424b5d7c8d637c00408c7a73da672b7f498521420b6dd3def12e42f3e487e9b14095aa8d5cc16a33491f1b50dadcf8811d1480f3fa8627")
+		if err != nil {
+			t.Fatalf("failed to deserialize expected hex: %v", err)
+		}
+		var kp KeyPair
+		if err := kp.UnmarshalBinary(expected); err != nil {
+			t.Fatalf("kp.UnmarshalBinary: %v", err)
+		}
+
+		var msk MiniSecretKey
+		sk := msk.ExpandEd25519()
+
+		if !kp.SecretKey().Equal(sk) {
+			t.Fatalf("sk != expected (Got %v)", sk)
+		}
+		if pk := sk.PublicKey(); !kp.PublicKey().Equal(pk) {
+			t.Fatalf("sk.PublicKey() != expected (Got %v)", pk)
+		}
+	})
+}
+
+func TestSecretKey(t *testing.T) {
+	t.Run("s11n", func(t *testing.T) {
+		sk, err := GenerateSecretKey(nil)
+		if err != nil {
+			t.Fatalf("GenerateSecretKey: %v", err)
+		}
+
+		b, err := sk.MarshalBinary()
+		if err != nil {
+			t.Fatalf("sk.MarshalBinary: %v", err)
+		}
+
+		var sk2 SecretKey
+		if err = sk2.UnmarshalBinary(b); err != nil {
+			t.Fatalf("sk2.UnmarshalBinary(b): %v", err)
+		}
+
+		if sk.key.Equal(sk2.key) != 1 {
+			t.Fatalf("sk.key != sk2.key (Got %v, %v)", sk.key, sk2.key)
+		}
+		if sk.nonce != sk2.nonce {
+			t.Fatalf("sk.nonce != sk2.nonce (Got %v, %v)", sk.nonce, sk2.nonce)
+		}
+
+		// Ensure uninitialized keys serialize.
+		var skUninit SecretKey
+
+		b, err = skUninit.MarshalBinary()
+		if err != nil {
+			t.Fatalf("skUninit.MarshalBinary: %v", err)
+		}
+
+		if l := len(b); l != SecretKeySize {
+			t.Fatalf("invalid serialized skUninit lenght: %v", l)
+		}
+		if !isAllZeros(b) {
+			t.Fatalf("invalid serialized skUnint (Got %v)", b)
+		}
+	})
+	t.Run("Equal", func(t *testing.T) {
+		sk, err := GenerateSecretKey(nil)
+		if err != nil {
+			t.Fatalf("GenerateSecretKey: %v", err)
+		}
+
+		if !sk.Equal(sk) {
+			t.Fatalf("sk != sk")
+		}
+
+		sk2, err := GenerateSecretKey(nil)
+		if err != nil {
+			t.Fatalf("GenerateSecretKey: %v", err)
+		}
+
+		if sk.Equal(sk2) {
+			t.Fatalf("sk == sk2")
+		}
+	})
+}
+
+func TestPublicKey(t *testing.T) {
+	t.Run("s11n", func(t *testing.T) {
+		kp, err := GenerateKeyPair(nil)
+		if err != nil {
+			t.Fatalf("GenerateKeyPair: %v", err)
+		}
+
+		pk := kp.PublicKey()
+		b, err := pk.MarshalBinary()
+		if err != nil {
+			t.Fatalf("pk.MarshalBinary: %v", err)
+		}
+
+		var pk2 PublicKey
+		if err = pk2.UnmarshalBinary(b); err != nil {
+			t.Fatalf("pk2.UnmarshalBinary(b): %v", err)
+		}
+
+		if pk.compressed.Equal(&pk2.compressed) != 1 {
+			t.Fatalf("pk.compressed != pk2.compressed (Got %v, %v)", pk.compressed, pk2.compressed)
+		}
+		if pk.point.Equal(pk2.point) != 1 {
+			t.Fatalf("pk.point != pk2.point (Got %v, %v)", pk.point, pk2.point)
+		}
+
+		// Ensure uninitialized keys serialize.
+		var pkUninit PublicKey
+
+		b, err = pkUninit.MarshalBinary()
+		if err != nil {
+			t.Fatalf("pkUninit.MarshalBinary: %v", err)
+		}
+
+		if l := len(b); l != PublicKeySize {
+			t.Fatalf("invalid serialized pkUninit lenght: %v", l)
+		}
+		if !isAllZeros(b) {
+			t.Fatalf("invalid serialized pkUnint (Got %v)", b)
+		}
+	})
+	t.Run("Equal", func(t *testing.T) {
+		kp, err := GenerateKeyPair(nil)
+		if err != nil {
+			t.Fatalf("GenerateKeyPair: %v", err)
+		}
+
+		pk := kp.PublicKey()
+		if !pk.Equal(pk) {
+			t.Fatalf("pk != pk")
+		}
+
+		kp2, err := GenerateKeyPair(nil)
+		if err != nil {
+			t.Fatalf("GenerateKeyPair: %v", err)
+		}
+
+		pk2 := kp2.PublicKey()
+		if pk.Equal(pk2) {
+			t.Fatalf("pk == pk2")
+		}
+	})
+}
+
+func TestKeyPair(t *testing.T) {
+	t.Run("s11n", func(t *testing.T) {
+		kp, err := GenerateKeyPair(nil)
+		if err != nil {
+			t.Fatalf("GenerateKeyPair: %v", err)
+		}
+
+		b, err := kp.MarshalBinary()
+		if err != nil {
+			t.Fatalf("kp.MarshalBinary: %v", err)
+		}
+
+		var kp2 KeyPair
+		if err = kp2.UnmarshalBinary(b); err != nil {
+			t.Fatalf("kp2.UnmarshalBinary: %v", err)
+		}
+
+		if !kp.sk.Equal(kp2.sk) {
+			t.Fatalf("kp.sk != kp2.sk (Got %v, %v)", kp.sk, kp2.sk)
+		}
+		if !kp.pk.Equal(kp2.pk) {
+			t.Fatalf("kp.pk != kp2.pk (Got %v, %v)", kp.pk, kp2.pk)
+		}
+
+		// Ensure uninitialized key pairs serialize.
+		var kpUninit KeyPair
+		b, err = kpUninit.MarshalBinary()
+		if err != nil {
+			t.Fatalf("kpUninit.MarshalBinary: %v", err)
+		}
+
+		if l := len(b); l != KeyPairSize {
+			t.Fatalf("invalid serialized kpUninit lenght: %v", l)
+		}
+		if !isAllZeros(b) {
+			t.Fatalf("invalid serialized kpUnint (Got %v)", b)
+		}
+	})
+}
+
+func BenchmarkGenerateKeyPair(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		if _, err := GenerateKeyPair(nil); err != nil {
+			b.Fatalf("GenerateKeyPair: %v", err)
+		}
+	}
+}

--- a/primitives/sr25519/sign.go
+++ b/primitives/sr25519/sign.go
@@ -1,0 +1,192 @@
+// Copyright (c) 2017-2019 isis agora lovecruft. All rights reserved.
+// Copyright (c) 2019 Web 3 Foundation. All rights reserved.
+// Copyright (c) 2021 Oasis Labs Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package sr25519
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/oasisprotocol/curve25519-voi/curve"
+	"github.com/oasisprotocol/curve25519-voi/curve/scalar"
+)
+
+// SignatureSize is the size of a sr25519 signature in bytes.
+const SignatureSize = 64
+
+func markSignatureSchnorrkel(b []byte) {
+	b[63] |= 128
+}
+
+var (
+	errSignatureNotMarkedSchnorrkel = fmt.Errorf("sr25519: not a sr25519 signature")
+
+	protoLabel = []byte("Schnorr-sig")
+	aLabel     = []byte("sign:pk")
+	rLabel     = []byte("sign:R")
+	cLabel     = []byte("sign:c")
+
+	witnessScalarLabel = []byte("signing")
+)
+
+type Signature struct {
+	rCompressed curve.CompressedRistretto
+	s           *scalar.Scalar
+}
+
+// UnmarshalBinary decodes a binary marshaled Signature.
+func (sig *Signature) UnmarshalBinary(data []byte) error {
+	sig.rCompressed.Identity()
+	sig.s = nil
+
+	if l := len(data); l != SignatureSize {
+		return fmt.Errorf("sr25519: bad Signature size: %v", l)
+	}
+
+	// Check that the upper-most bit is set (to distinguish sr25519
+	// signatures from Ed25519 signatures).
+	if data[63]&128 == 0 {
+		return errSignatureNotMarkedSchnorrkel
+	}
+
+	// Copy and clear the upper-most bit.
+	var upper [scalar.ScalarSize]byte
+	copy(upper[:], data[32:])
+	upper[31] &= 127
+
+	// Check that the scalar is encoded in canonical form.
+	if !scalar.ScMinimal(upper[:]) {
+		return fmt.Errorf("sr25519: non-canonical signature scalar")
+	}
+	sigScalar, err := scalar.NewFromCanonicalBytes(upper[:])
+	if err != nil {
+		return fmt.Errorf("sr25519: failed to deserialize signature scalar: %v", err)
+	}
+
+	// Copy (but do not decompress) the point.
+	if _, err := sig.rCompressed.SetBytes(data[:32]); err != nil {
+		return fmt.Errorf("sr25519: failed to deserialize signature point: %v", err)
+	}
+
+	sig.s = sigScalar
+
+	return nil
+}
+
+// MarshalBinary encodes a Signature into binary form.
+func (sig *Signature) MarshalBinary() ([]byte, error) {
+	var b []byte
+
+	switch sig.s {
+	case nil:
+		b = make([]byte, SignatureSize)
+	default:
+		b = make([]byte, 0, SignatureSize)
+		b = append(b, sig.rCompressed[:]...)
+
+		scalarBytes, err := sig.s.MarshalBinary()
+		if err != nil {
+			return nil, fmt.Errorf("sr25519: failed to serialize signature scalar: %v", err)
+		}
+
+		b = append(b, scalarBytes...)
+	}
+
+	markSignatureSchnorrkel(b)
+
+	return b, nil
+}
+
+// NewSignatureFromBytes constructs a Signature from the byte representation.
+func NewSignatureFromBytes(b []byte) (*Signature, error) {
+	var s Signature
+	if err := s.UnmarshalBinary(b); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+func deriveVerifyChallengeScalar(publicKey *PublicKey, transcript *SigningTranscript, signature *Signature) *scalar.Scalar {
+	t := transcript.clone()
+	t.protoName(protoLabel)
+	t.commitPoint(aLabel, &publicKey.compressed)
+	t.commitPoint(rLabel, &signature.rCompressed)
+	return t.challengeScalar(cLabel)
+}
+
+// Verify verifies a signature by a public key on a transcript.
+func (pk *PublicKey) Verify(transcript *SigningTranscript, signature *Signature) bool {
+	if pk.point == nil || signature.s == nil {
+		return false
+	}
+
+	var r curve.RistrettoPoint
+	if _, err := r.SetCompressed(&signature.rCompressed); err != nil {
+		return false
+	}
+
+	var negA curve.RistrettoPoint
+	negA.Neg(pk.point)
+
+	k := deriveVerifyChallengeScalar(pk, transcript, signature)
+
+	var rDiff curve.RistrettoPoint
+	return rDiff.TripleScalarMulBasepointVartime(k, &negA, signature.s, &r).IsIdentity()
+}
+
+// Sign signs a transcript with a key pair, and provided entropy source.
+// If rng is nil, crypto/rand.Reader will be used.
+func (kp *KeyPair) Sign(rng io.Reader, transcript *SigningTranscript) (*Signature, error) {
+	t := transcript.clone()
+	t.protoName(protoLabel)
+	t.commitPoint(aLabel, &kp.pk.compressed)
+
+	rScalar, err := t.witnessScalar(witnessScalarLabel, [][]byte{kp.sk.nonce[:]}, rng)
+	if err != nil {
+		return nil, fmt.Errorf("sr25519: failed to generate witness scalar: %w", err)
+	}
+
+	var (
+		sig Signature
+		r   curve.RistrettoPoint
+	)
+	r.MulBasepoint(curve.RISTRETTO_BASEPOINT_TABLE, rScalar)
+	sig.rCompressed.SetRistrettoPoint(&r)
+
+	t.commitPoint(rLabel, &sig.rCompressed)
+
+	k := t.challengeScalar(cLabel)
+
+	sig.s = scalar.New().Mul(k, kp.sk.key)
+	sig.s.Add(sig.s, rScalar)
+
+	return &sig, nil
+}

--- a/primitives/sr25519/sign_test.go
+++ b/primitives/sr25519/sign_test.go
@@ -1,0 +1,187 @@
+// Copyright (c) 2021 Oasis Labs Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+// IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+// TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+// TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package sr25519
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+func TestSignS11n(t *testing.T) {
+	// Round trip is covered by TestSignVerify.
+
+	var sigUninit Signature
+	b, err := sigUninit.MarshalBinary()
+	if err != nil {
+		t.Fatalf("skUninit.MarshalBinary: %v", err)
+	}
+
+	if l := len(b); l != SignatureSize {
+		t.Fatalf("invalid serialized sigUninit lenght: %v", l)
+	}
+	if !isAllZeros(b[:63]) || b[63] != 128 {
+		t.Fatalf("invalid serialized sigUnint (Got %v)", b)
+	}
+}
+
+func TestSignVerify(t *testing.T) {
+	kp, err := GenerateKeyPair(nil)
+	if err != nil {
+		t.Fatalf("failed to GenerateKeyPair: %v", err)
+	}
+
+	msg := []byte("I hurt myself today, to see if I still feel")
+	sc := NewSigningContext([]byte("test context pls ignore"))
+	st := sc.NewTranscriptBytes(msg)
+
+	sig, err := kp.Sign(nil, st)
+	if err != nil {
+		t.Fatalf("failed to Sign: %v", err)
+	}
+	sigBytes, err := sig.MarshalBinary()
+	if err != nil {
+		t.Fatalf("failed to serialize signature: %v", err)
+	}
+
+	var vSig Signature
+	if err := vSig.UnmarshalBinary(sigBytes); err != nil {
+		t.Fatalf("failed to deserialize signature: %v", err)
+	}
+
+	// Re-use the same transcript used when signing to test that it is
+	// side-effect free.
+	if !kp.PublicKey().Verify(st, &vSig) {
+		t.Fatalf("failed to verify signature: %v", err)
+	}
+}
+
+func TestVerifyVector(t *testing.T) {
+	// You would figure, that people will learn at some point to provide
+	// test vectors, especially given all the pain that's come from
+	// edge cases etc with the algorithm this was ostensibly created
+	// to replace, but you would be wrong.
+	//
+	// While I'm ranting about this, you would figure, that people
+	// would learn to actually write a detailed specification of the
+	// algorithm, but you would be wrong, again.
+	//
+	// Just steal the test vector from go-schnorrkel for now.  It is
+	// probably the only thing that god-forsaken module is good for
+	// at this point.
+
+	const (
+		pkHex  = "46ebddef8cd9bb167dc30878d7113b7e168e6f0646beffd77d69d39bad76b47a"
+		sigHex = "4e172314444b8f820bb54c22e95076f220ed25373e5c178234aa6c211d29271244b947e3ff3418ff6b45fd1df1140c8cbff69fc58ee6dc96df70936a2bb74b82"
+		msg    = "this is a message"
+	)
+
+	pkBytes, err := hex.DecodeString(pkHex)
+	if err != nil {
+		t.Fatalf("failed to deserialize public key hex: %v", err)
+	}
+	var pk PublicKey
+	if err := pk.UnmarshalBinary(pkBytes); err != nil {
+		t.Fatalf("failed to deserialize public key: %v", err)
+	}
+
+	sigBytes, err := hex.DecodeString(sigHex)
+	if err != nil {
+		t.Fatalf("failed to deserialize signature hex: %v", err)
+	}
+	var sig Signature
+	if err := sig.UnmarshalBinary(sigBytes); err != nil {
+		t.Fatalf("failed to deserialize signature: %v", err)
+	}
+
+	sc := NewSigningContext([]byte("substrate"))
+	st := sc.NewTranscriptBytes([]byte(msg))
+	if !pk.Verify(st, &sig) {
+		t.Fatalf("signature failed to verify")
+	}
+
+	st = sc.NewTranscriptBytes([]byte("wrong message"))
+	if pk.Verify(st, &sig) {
+		t.Fatalf("bad signature verified")
+	}
+}
+
+func makeBenchTranscript(sc *SigningContext) *SigningTranscript {
+	msg := []byte("Test message")
+	return sc.NewTranscriptBytes(msg)
+}
+
+func BenchmarkSigning(b *testing.B) {
+	kp, err := GenerateKeyPair(nil)
+	if err != nil {
+		b.Fatalf("failed to GenerateKeyPair: %v", err)
+	}
+
+	sc := NewSigningContext([]byte("benchmark-signature"))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		st := makeBenchTranscript(sc)
+		sig, err := kp.Sign(nil, st)
+		if err != nil {
+			b.Fatalf("failed to Sign: %v", err)
+		}
+
+		b.StopTimer()
+		if !kp.PublicKey().Verify(st, sig) {
+			b.Fatalf("Verify failed")
+		}
+		b.StartTimer()
+	}
+}
+
+func BenchmarkVerification(b *testing.B) {
+	kp, err := GenerateKeyPair(nil)
+	if err != nil {
+		b.Fatalf("failed to GenerateKeyPair: %v", err)
+	}
+
+	sc := NewSigningContext([]byte("benchmark-signature"))
+	st := makeBenchTranscript(sc)
+	sig, err := kp.Sign(nil, st)
+	if err != nil {
+		b.Fatalf("failed to sign: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if !kp.PublicKey().Verify(st, sig) {
+			b.Fatalf("Verify failed")
+		}
+	}
+}


### PR DESCRIPTION
Because it is a better algorithm, and people should use it, implement sr25519.  This is a notable improvement over the existing Go implementation that appears to be popular because:

 * It is a lot faster in part due to:
   * The underlying operations using a lot more assembly.
   * Not having to re-derive the public key each time the user signs.
   * Instead of calculating the verification by hand (lolololololol), we do it in one-shot.
 * It is more correct:
   * ~The s11n routines are more idiomatic (and probably actually work as intended).~ (Fixed)
   * ~This actually samples 128-bit random scalars when doing batch verification.~ (Fixed)
   * This uses a transcript RNG, instead of YOLO ignoring the private key nonce.
 * Support for SigningContext instead of having to work with a merlin transcript.
 * A more idiomatic/nicer API:
   * Not having foot+gun API calls like `MiniSecretKey.Public()`.
   * Can override the entropy source wherever one is called for.
   * BinaryMarshaler/BinaryUnmarshaler instead of the Encode/Compress/Decode/whatever.

TODO:
 * [x] Write tests for the key generation/s11n.
 * [x] Implement batch verification.
 * [x] Add license information.

TODO (deferred to a later date):
 * (perf) Replace the strobe implementation with something that doesn't guzzle heap.
 * (feature) Implement the VRF construct (The w3f repo has an issue hinting that this will change).
 * (feature) Implement the HKD construct.

Part of #4 