### PR TITLE
primitives/ed25519: Optimize for very large batches

### DIFF
--- a/curve/edwards.go
+++ b/curve/edwards.go
@@ -241,6 +241,11 @@ func (p *EdwardsPoint) Set(t *EdwardsPoint) *EdwardsPoint {
 	return p
 }
 
+// SetExpanded sets the Edwards point to the expanded point.
+func (p *EdwardsPoint) SetExpanded(expandedPoint *ExpandedEdwardsPoint) *EdwardsPoint {
+	return p.Set(&expandedPoint.point)
+}
+
 // SetCompressedY attempts to decompress a CompressedEdwardsY into an
 // EdwardsPoint.
 //

--- a/curve/ristretto.go
+++ b/curve/ristretto.go
@@ -190,6 +190,12 @@ func (p *RistrettoPoint) Set(t *RistrettoPoint) *RistrettoPoint {
 	return p
 }
 
+// SetExpanded sets the Ristretto point to the expanded point.
+func (p *RistrettoPoint) SetExpanded(expandedPoint *ExpandedRistrettoPoint) *RistrettoPoint {
+	p.inner.Set(&expandedPoint.inner.point)
+	return p
+}
+
 // SetCompressed attempts to decompress a CompressedRistretto into a
 // RistrettoPoint.
 func (p *RistrettoPoint) SetCompressed(compressed *CompressedRistretto) (*RistrettoPoint, error) {


### PR DESCRIPTION
This implements proposal 1 in #70.  The added complexity isn't too bad, and I think the behavior is better.

Observations:
 * This is faster for `PublicKey` based large batches (because the unneeded table precomputation is omitted).
 * This uses dramatically less memory for `PublicKey` based large batches.
 * `ExpandedPublicKey` based batches have increased memory consumption due to storing an extra decompressed `curve.EdwardsPoint` per entry.

Possible improvements:
 * ~If `NewBatchVerifierWithCapacity` is used with a sufficiently large capacity, this could skip attempting to expand public keys all together.  The sticking point for me would be what to do on `Reset()`, should a verifier remember that it was previously used for a large batch?~ Opted for `v.ForceNoPublicKeyExpansion()` instead.
 * The cutover threshold for when the code gives up is currently identical between the precomputed and non-precomputed multiscalar multiplies.  Intuitively it should be slightly larger for the precomputed case, but this will take benchmarking.

TODO:
 * [x] Add a mountain of test cases.

```
name                                old time/op    new time/op    delta
VerifyBatchOnly/1-8                    105µs ± 0%     106µs ± 0%   +0.82%
VerifyBatchOnly/2-8                    149µs ± 0%     151µs ± 0%   +1.28%
VerifyBatchOnly/4-8                    235µs ± 0%     236µs ± 0%   +0.58%
VerifyBatchOnly/8-8                    406µs ± 0%     410µs ± 0%   +1.05%
VerifyBatchOnly/16-8                   756µs ± 0%     760µs ± 0%   +0.64%
VerifyBatchOnly/32-8                  1.43ms ± 0%    1.45ms ± 0%   +0.83%
VerifyBatchOnly/64-8                  2.80ms ± 0%    2.84ms ± 0%   +1.25%
VerifyBatchOnly/128-8                 5.48ms ± 0%    5.36ms ± 0%   -2.05%
VerifyBatchOnly/256-8                 10.3ms ± 0%     9.8ms ± 0%   -4.66%
VerifyBatchOnly/384-8                 14.7ms ± 0%    13.9ms ± 0%   -5.63%
VerifyBatchOnly/512-8                 19.5ms ± 0%    18.1ms ± 0%   -7.06%
VerifyBatchOnly/768-8                 28.2ms ± 0%    25.9ms ± 0%   -8.11%
VerifyBatchOnly/1024-8                36.8ms ± 0%    33.8ms ± 0%   -8.19%
GenerateKey/voi-8                     26.0µs ± 0%    25.7µs ± 0%   -1.03%
GenerateKey/stdlib-8                   105µs ± 0%     106µs ± 0%   +0.40%
NewKeyFromSeed/voi-8                  26.2µs ± 0%    25.5µs ± 0%   -2.65%
NewKeyFromSeed/stdlib-8                105µs ± 0%     105µs ± 0%   -0.13%
Signing/voi-8                         28.4µs ± 0%    28.8µs ± 0%   +1.37%
Signing/stdlib-8                       108µs ± 0%     108µs ± 0%   +0.11%
Verification/voi-8                    77.0µs ± 0%    74.8µs ± 0%   -2.78%
Verification/voi_stdlib-8             83.2µs ± 0%    83.4µs ± 0%   +0.17%
Verification/stdlib-8                  297µs ± 0%     300µs ± 0%   +0.86%
Expanded/NewExpandedPublicKey-8       11.7µs ± 0%    11.6µs ± 0%   -0.23%
Expanded/Verification/voi-8           63.1µs ± 0%    62.7µs ± 0%   -0.68%
Expanded/Verification/voi_stdlib-8    74.3µs ± 0%    75.8µs ± 0%   +2.06%
Expanded/VerifyBatchOnly/1-8          92.6µs ± 0%    93.7µs ± 0%   +1.11%
Expanded/VerifyBatchOnly/2-8           124µs ± 0%     126µs ± 0%   +0.92%
Expanded/VerifyBatchOnly/4-8           188µs ± 0%     190µs ± 0%   +1.29%
Expanded/VerifyBatchOnly/8-8           314µs ± 0%     314µs ± 0%   -0.01%
Expanded/VerifyBatchOnly/16-8          563µs ± 0%     565µs ± 0%   +0.38%
Expanded/VerifyBatchOnly/32-8         1.05ms ± 0%    1.06ms ± 0%   +0.40%
Expanded/VerifyBatchOnly/64-8         2.05ms ± 0%    2.06ms ± 0%   +0.49%
Expanded/VerifyBatchOnly/128-8        3.93ms ± 0%    3.98ms ± 0%   +1.41%
Expanded/VerifyBatchOnly/256-8        7.15ms ± 0%    7.19ms ± 0%   +0.57%
Expanded/VerifyBatchOnly/384-8        10.1ms ± 0%    10.2ms ± 0%   +1.19%
Expanded/VerifyBatchOnly/512-8        13.4ms ± 0%    13.5ms ± 0%   +1.03%
Expanded/VerifyBatchOnly/768-8        19.0ms ± 0%    19.1ms ± 0%   +0.05%
Expanded/VerifyBatchOnly/1024-8       24.4ms ± 0%    24.5ms ± 0%   +0.51%

name                                old alloc/op   new alloc/op   delta
VerifyBatchOnly/1-8                   5.43kB ± 0%    5.59kB ± 0%   +2.95%
VerifyBatchOnly/2-8                   9.54kB ± 0%   10.02kB ± 0%   +5.03%
VerifyBatchOnly/4-8                   17.4kB ± 0%    18.5kB ± 0%   +6.45%
VerifyBatchOnly/8-8                   34.0kB ± 0%    36.2kB ± 0%   +6.69%
VerifyBatchOnly/16-8                  65.8kB ± 0%    70.0kB ± 0%   +6.37%
VerifyBatchOnly/32-8                   138kB ± 0%     146kB ± 0%   +5.84%
VerifyBatchOnly/64-8                   267kB ± 0%     283kB ± 0%   +6.08%
VerifyBatchOnly/128-8                  353kB ± 0%     332kB ± 0%   -5.92%
VerifyBatchOnly/256-8                  701kB ± 0%     519kB ± 0%  -25.88%
VerifyBatchOnly/384-8                 1.13MB ± 0%    0.82MB ± 0%  -27.45%
VerifyBatchOnly/512-8                 1.40MB ± 0%    0.90MB ± 0%  -35.92%
VerifyBatchOnly/768-8                 2.25MB ± 0%    1.49MB ± 0%  -33.78%
VerifyBatchOnly/1024-8                2.76MB ± 0%    1.61MB ± 0%  -41.55%
GenerateKey/voi-8                       128B ± 0%      128B ± 0%    0.00%
GenerateKey/stdlib-8                    128B ± 0%      128B ± 0%    0.00%
NewKeyFromSeed/voi-8                   0.00B          0.00B         0.00%
NewKeyFromSeed/stdlib-8                0.00B          0.00B         0.00%
Signing/voi-8                          64.0B ± 0%     64.0B ± 0%    0.00%
Signing/stdlib-8                       0.00B          0.00B         0.00%
Verification/voi-8                     0.00B          0.00B         0.00%
Verification/voi_stdlib-8              0.00B          0.00B         0.00%
Verification/stdlib-8                  0.00B          0.00B         0.00%
Expanded/NewExpandedPublicKey-8       1.50kB ± 0%    1.50kB ± 0%    0.00%
Expanded/Verification/voi-8            0.00B          0.00B         0.00%
Expanded/Verification/voi_stdlib-8     0.00B          0.00B         0.00%
Expanded/VerifyBatchOnly/1-8          3.93kB ± 0%    4.09kB ± 0%   +4.07%
Expanded/VerifyBatchOnly/2-8          6.54kB ± 0%    7.02kB ± 0%   +7.34%
Expanded/VerifyBatchOnly/4-8          11.4kB ± 0%    12.5kB ± 0%   +9.86%
Expanded/VerifyBatchOnly/8-8          21.9kB ± 0%    24.2kB ± 0%  +10.36%
Expanded/VerifyBatchOnly/16-8         41.8kB ± 0%    46.0kB ± 0%  +10.03%
Expanded/VerifyBatchOnly/32-8         89.4kB ± 0%    97.5kB ± 0%   +8.98%
Expanded/VerifyBatchOnly/64-8          171kB ± 0%     187kB ± 0%   +9.51%
Expanded/VerifyBatchOnly/128-8         161kB ± 0%     192kB ± 0%  +19.73%
Expanded/VerifyBatchOnly/256-8         316kB ± 0%     379kB ± 0%  +20.23%
Expanded/VerifyBatchOnly/384-8         550kB ± 0%     678kB ± 0%  +23.28%
Expanded/VerifyBatchOnly/512-8         630kB ± 0%     757kB ± 0%  +20.21%
Expanded/VerifyBatchOnly/768-8        1.09MB ± 0%    1.35MB ± 0%  +23.55%
Expanded/VerifyBatchOnly/1024-8       1.22MB ± 0%    1.47MB ± 0%  +20.92%

name                                old allocs/op  new allocs/op  delta
VerifyBatchOnly/1-8                     12.0 ± 0%      12.0 ± 0%    0.00%
VerifyBatchOnly/2-8                     15.0 ± 0%      15.0 ± 0%    0.00%
VerifyBatchOnly/4-8                     20.0 ± 0%      20.0 ± 0%    0.00%
VerifyBatchOnly/8-8                     29.0 ± 0%      29.0 ± 0%    0.00%
VerifyBatchOnly/16-8                    46.0 ± 0%      46.0 ± 0%    0.00%
VerifyBatchOnly/32-8                    79.0 ± 0%      79.0 ± 0%    0.00%
VerifyBatchOnly/64-8                     144 ± 0%       144 ± 0%    0.00%
VerifyBatchOnly/128-8                    273 ± 0%       201 ± 0%  -26.37%
VerifyBatchOnly/256-8                    530 ± 0%       202 ± 0%  -61.89%
VerifyBatchOnly/384-8                    787 ± 0%       203 ± 0%  -74.21%
VerifyBatchOnly/512-8                  1.04k ± 0%     0.20k ± 0%  -80.54%
VerifyBatchOnly/768-8                  1.56k ± 0%     0.20k ± 0%  -86.89%
VerifyBatchOnly/1024-8                 2.07k ± 0%     0.20k ± 0%  -90.14%
GenerateKey/voi-8                       3.00 ± 0%      3.00 ± 0%    0.00%
GenerateKey/stdlib-8                    3.00 ± 0%      3.00 ± 0%    0.00%
NewKeyFromSeed/voi-8                    0.00           0.00         0.00%
NewKeyFromSeed/stdlib-8                 0.00           0.00         0.00%
Signing/voi-8                           1.00 ± 0%      1.00 ± 0%    0.00%
Signing/stdlib-8                        0.00           0.00         0.00%
Verification/voi-8                      0.00           0.00         0.00%
Verification/voi_stdlib-8               0.00           0.00         0.00%
Verification/stdlib-8                   0.00           0.00         0.00%
Expanded/NewExpandedPublicKey-8         2.00 ± 0%      2.00 ± 0%    0.00%
Expanded/Verification/voi-8             0.00           0.00         0.00%
Expanded/Verification/voi_stdlib-8      0.00           0.00         0.00%
Expanded/VerifyBatchOnly/1-8            10.0 ± 0%      10.0 ± 0%    0.00%
Expanded/VerifyBatchOnly/2-8            11.0 ± 0%      11.0 ± 0%    0.00%
Expanded/VerifyBatchOnly/4-8            12.0 ± 0%      12.0 ± 0%    0.00%
Expanded/VerifyBatchOnly/8-8            13.0 ± 0%      13.0 ± 0%    0.00%
Expanded/VerifyBatchOnly/16-8           14.0 ± 0%      14.0 ± 0%    0.00%
Expanded/VerifyBatchOnly/32-8           15.0 ± 0%      15.0 ± 0%    0.00%
Expanded/VerifyBatchOnly/64-8           16.0 ± 0%      16.0 ± 0%    0.00%
Expanded/VerifyBatchOnly/128-8          17.0 ± 0%      15.0 ± 0%  -11.76%
Expanded/VerifyBatchOnly/256-8          18.0 ± 0%      16.0 ± 0%  -11.11%
Expanded/VerifyBatchOnly/384-8          19.0 ± 0%      17.0 ± 0%  -10.53%
Expanded/VerifyBatchOnly/512-8          19.0 ± 0%      17.0 ± 0%  -10.53%
Expanded/VerifyBatchOnly/768-8          20.0 ± 0%      18.0 ± 0%  -10.00%
Expanded/VerifyBatchOnly/1024-8         20.0 ± 0%      18.0 ± 0%  -10.00%
```

