### PR TITLE
internal/field: Fix `testSetBytesHighBitIsIgnored`

### DIFF
--- a/internal/field/field_test.go
+++ b/internal/field/field_test.go
@@ -298,7 +298,7 @@ func testSetBytesHighBitIsIgnored(t *testing.T) {
 	clearedBytes := bBytes
 	clearedBytes[31] &= 127
 
-	if _, err := withoutHighBitSet.SetBytes(bBytes[:]); err != nil {
+	if _, err := withoutHighBitSet.SetBytes(clearedBytes[:]); err != nil {
 		t.Fatalf("withoutHighBitSet SetBytes(): %v", err)
 	}
 


### PR DESCRIPTION
Oops.  Lots of other things break if this is broken at least, so this
just makes it so that the test can catch future bugs.