### PR TITLE
field: Special case multiply by `A+2/4` for the 64-bit path

### DIFF
--- a/curve/constants_u32.go
+++ b/curve/constants_u32.go
@@ -190,9 +190,6 @@ var constINVSQRT_A_MINUS_D = field.NewElement2625(
 	6111466, 4156064, 39310137, 12243467, 41204824, 120896, 20826367, 26493656, 6093567, 31568420,
 )
 
-// `APLUS2_OVER_FOUR` is (A+2)/4. (This is used internally within the Montgomery ladder.)
-var constAPLUS2_OVER_FOUR = field.NewElement2625(121666, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-
 // `[2^128]B`
 var constB_SHL_128 = newEdwardsPoint(
 	field.NewElement2625(

--- a/curve/constants_u64.go
+++ b/curve/constants_u64.go
@@ -272,9 +272,6 @@ var constINVSQRT_A_MINUS_D = field.NewElement51(
 	2118520810568447,
 )
 
-// `APLUS2_OVER_FOUR` is (A+2)/4. (This is used internally within the Montgomery ladder.)
-var constAPLUS2_OVER_FOUR = field.NewElement51(121666, 0, 0, 0, 0)
-
 // `[2^128]B`
 var constB_SHL_128 = newEdwardsPoint(
 	field.NewElement51(

--- a/curve/montgomery.go
+++ b/curve/montgomery.go
@@ -153,7 +153,7 @@ func montgomeryDifferentialAddAndDouble(P, Q *montgomeryProjectivePoint, affine_
 	Q.U.Square(&Q.U) // 4 (U_P U_Q - W_P W_Q)^2: t11
 	Q.W.Square(&Q.W) // 4 (W_P U_Q - U_P W_Q)^2: t12
 
-	P.W.Mul(&constAPLUS2_OVER_FOUR, &t6) // (A + 2) U_P U_Q: t13
+	P.W.Mul121666(&t6) // (A + 2) U_P U_Q: t13
 
 	P.U.Mul(&t4, &t5)  // ((U_P + W_P)(U_P - W_P))^2 = (U_P^2 - W_P^2)^2: t14
 	P.W.Add(&P.W, &t5) // (U_P - W_P)^2 + (A + 2) U_P W_P: t15

--- a/internal/field/constants_u32.go
+++ b/internal/field/constants_u32.go
@@ -39,3 +39,6 @@ var SQRT_M1 = NewElement2625(
 	34513072, 25610706, 9377949, 3500415, 12389472,
 	33281959, 41962654, 31548777, 326685, 11406482,
 )
+
+// `APLUS2_OVER_FOUR` is (A+2)/4. (This is used internally within the Montgomery ladder.)
+var constAPLUS2_OVER_FOUR = NewElement2625(121666, 0, 0, 0, 0, 0, 0, 0, 0, 0)

--- a/internal/field/field_u32.go
+++ b/internal/field/field_u32.go
@@ -153,6 +153,11 @@ func (fe *Element) Mul(a, b *Element) *Element {
 	return fe.reduce(&[10]uint64{z0, z1, z2, z3, z4, z5, z6, z7, z8, z9})
 }
 
+// Mul121666 sets `fe = t * 121666`, and returns fe.
+func (fe *Element) Mul121666(t *Element) *Element {
+	return fe.Mul(t, &constAPLUS2_OVER_FOUR)
+}
+
 // Neg sets `fe = -t`, and returns fe.
 func (fe *Element) Neg(t *Element) *Element {
 	// Compute -b as ((2^4 * p) - b) to avoid underflow.


### PR DESCRIPTION
It's a decent optimization to make, I should also do it for the 32-bit
path, but I'm lazy and the majority of users are likely using 64-bit
systems.

```
ScalarMult/voi/debugNoXcurve-4     251µs ± 0%     235µs ± 0%  -6.41%  (p=0.008 n=5+5)
```