### PR TITLE
primitives/ed25519/extra/ecvrf: Add optional proof non-determinism

### DIFF
--- a/curve/edwards.go
+++ b/curve/edwards.go
@@ -139,8 +139,8 @@ func (p *CompressedEdwardsY) Identity() *CompressedEdwardsY {
 	return p
 }
 
-// IsCanonical returns true if p is a canonical encoding in variable-time.
-func (p *CompressedEdwardsY) IsCanonical() bool {
+// IsCanonicalVartime returns true if p is a canonical encoding in variable-time.
+func (p *CompressedEdwardsY) IsCanonicalVartime() bool {
 	// Check that Y is canonical, using the succeed-fast algorithm from
 	// the "Taming the many EdDSAs" paper.
 	yCanonical := func() bool {

--- a/curve/edwards_test.go
+++ b/curve/edwards_test.go
@@ -143,7 +143,7 @@ func TestEdwards(t *testing.T) {
 	t.Run("MultiscalarMulPippengerVartime", testEdwardsMultiscalarMulPippengerVartime)
 	t.Run("AffineNielsPoint/ConditionalAssign", testAffineNielsConditionalAssign)
 	t.Run("AffineNielsPoint/ConversionClearsDenominators", testAffineNielsConversionClearsDenominators)
-	t.Run("IsCanonical", testIsCanonical)
+	t.Run("IsCanonicalVartime", testIsCanonicalVartime)
 }
 
 func testEdwardsDecompressionCompression(t *testing.T) {
@@ -589,7 +589,7 @@ func testAffineNielsConversionClearsDenominators(t *testing.T) {
 	}
 }
 
-func testIsCanonical(t *testing.T) {
+func testIsCanonicalVartime(t *testing.T) {
 	// Check to see that the hard-coded compressed points with non-canonical
 	// sign bits are indeed non-canonical.
 	for _, p := range noncanonicalSignBits {
@@ -602,8 +602,8 @@ func testIsCanonical(t *testing.T) {
 			t.Fatalf("pCheck == p (p: %v pCheck: %v)", p, pCheck)
 		}
 
-		if p.IsCanonical() {
-			t.Fatalf("p.IsCanonical() == true (p: %v)", p)
+		if p.IsCanonicalVartime() {
+			t.Fatalf("p.IsCanonicalVartime() == true (p: %v)", p)
 		}
 	}
 }

--- a/curve/scalar/sc_minimal.go
+++ b/curve/scalar/sc_minimal.go
@@ -44,13 +44,13 @@ var order = func() [4]uint64 {
 	return ret
 }()
 
-// ScMinimal returns true if the given byte-encoded scalar is less than
-// the order of the curve, in variable-time.
+// ScMinimalVartime returns true if the given byte-encoded scalar is
+// less than the order of the curve, in variable-time.
 //
 // This method is intended for verification applications, and is
 // significantly faster than deserializing the scalar and calling
 // IsCanonical.
-func ScMinimal(scalar []byte) bool {
+func ScMinimalVartime(scalar []byte) bool {
 	if scalar[31]&240 == 0 {
 		// 4 most significant bits unset, succeed fast
 		return true

--- a/curve/scalar/scalar_test.go
+++ b/curve/scalar/scalar_test.go
@@ -117,7 +117,7 @@ func TestScalar(t *testing.T) {
 	t.Run("BatchInvert/Empty", testBatchInvertEmpty)
 	t.Run("BatchInvert/Consistency", testBatchInvertConsistency)
 	t.Run("PippengerRadix", testPippengerRadix)
-	t.Run("ScMinimal", testScMinimal)
+	t.Run("ScMinimalVartime", testScMinimalVartime)
 }
 
 func testFuzzerTestcaseReduction(t *testing.T) {
@@ -681,7 +681,7 @@ func testPippengerRadix(t *testing.T) {
 	}
 }
 
-func testScMinimal(t *testing.T) {
+func testScMinimalVartime(t *testing.T) {
 	// At this point I could have just left this hardcoded as in the
 	// Go standard library, but parsing out BASEPOINT_ORDER is probably
 	// better.
@@ -708,8 +708,8 @@ func testScMinimal(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to decode test scalar: %v", err)
 		}
-		if ScMinimal(b) != v.expected {
-			t.Fatalf("ScMinimal(%s) != %v", v.scalarHex, v.expected)
+		if ScMinimalVartime(b) != v.expected {
+			t.Fatalf("ScMinimalVartime(%s) != %v", v.scalarHex, v.expected)
 		}
 	}
 }

--- a/primitives/ed25519/ed25519.go
+++ b/primitives/ed25519/ed25519.go
@@ -250,7 +250,7 @@ func (vOpts *VerifyOptions) unpackPublicKey(publicKey PublicKey, A *curve.Edward
 	}
 
 	// Check if A is canonical.
-	if !vOpts.AllowNonCanonicalA && !aCompressed.IsCanonical() {
+	if !vOpts.AllowNonCanonicalA && !aCompressed.IsCanonicalVartime() {
 		return false
 	}
 
@@ -264,7 +264,7 @@ func (vOpts *VerifyOptions) unpackSignature(sig []byte, R *curve.EdwardsPoint, S
 
 	// https://tools.ietf.org/html/rfc8032#section-5.1.7 requires that s be in
 	// the range [0, order) in order to prevent signature malleability.
-	if !scalar.ScMinimal(sig[32:]) {
+	if !scalar.ScMinimalVartime(sig[32:]) {
 		return false
 	}
 
@@ -288,7 +288,7 @@ func (vOpts *VerifyOptions) unpackSignature(sig []byte, R *curve.EdwardsPoint, S
 	}
 
 	// Check if R is canonical.
-	if !vOpts.AllowNonCanonicalR && !rCompressed.IsCanonical() {
+	if !vOpts.AllowNonCanonicalR && !rCompressed.IsCanonicalVartime() {
 		return false
 	}
 

--- a/primitives/ed25519/ed25519_precomputation.go
+++ b/primitives/ed25519/ed25519_precomputation.go
@@ -91,7 +91,7 @@ func NewExpandedPublicKey(publicKey PublicKey) (*ExpandedPublicKey, error) {
 
 	// Check before negating the point.
 	pre.isSmallOrder = p.IsSmallOrder()
-	pre.isCanonical = pre.compressed.IsCanonical()
+	pre.isCanonical = pre.compressed.IsCanonicalVartime()
 
 	// Serial verification uses -A, batch verification can just negate
 	// the corresponding scalar (dirt cheap), and it saves carrying

--- a/primitives/ed25519/ed25519vectors_test.go
+++ b/primitives/ed25519/ed25519vectors_test.go
@@ -169,7 +169,7 @@ func TestEd25519Vectors(t *testing.T) {
 	})
 }
 
-func TestIsCanonical(t *testing.T) {
+func TestIsCanonicalVartime(t *testing.T) {
 	// This should live in the curve package, but this is where the convenient
 	// test vectors live.
 	for i, vec := range ed25519Vectors {
@@ -188,14 +188,14 @@ func TestIsCanonical(t *testing.T) {
 			if _, err := p.SetBytes(vec.PublicKey(t)); err != nil {
 				t.Fatalf("failed to deserialize A: %v", err)
 			}
-			if isCanonical := p.IsCanonical(); isCanonical != canonicalA {
-				t.Fatalf("A.IsCanonical() mismatch: %v (%v)", isCanonical, canonicalA)
+			if isCanonical := p.IsCanonicalVartime(); isCanonical != canonicalA {
+				t.Fatalf("A.IsCanonicalVartime() mismatch: %v (%v)", isCanonical, canonicalA)
 			}
 			if _, err := p.SetBytes(vec.R(t)); err != nil {
 				t.Fatalf("failed to deserialize R: %v", err)
 			}
-			if isCanonical := p.IsCanonical(); isCanonical != canonicalR {
-				t.Fatalf("R.IsCanonical() mismatch: %v (%v)", isCanonical, canonicalR)
+			if isCanonical := p.IsCanonicalVartime(); isCanonical != canonicalR {
+				t.Fatalf("R.IsCanonicalVartime() mismatch: %v (%v)", isCanonical, canonicalR)
 			}
 		})
 	}

--- a/primitives/ed25519/extra/ecvrf/ecvrf.go
+++ b/primitives/ed25519/extra/ecvrf/ecvrf.go
@@ -185,7 +185,8 @@ func doProve(rand io.Reader, sk ed25519.PrivateKey, alphaString []byte) ([]byte,
 	return piString[:], nil
 }
 
-// ProofToHash implements ECVRF_proof_to_hash for the suite ECVRF-EDWARDS25519-SHA512-ELL2.
+// ProofToHash implements ECVRF_proof_to_hash for the suite ECVRF-EDWARDS25519-SHA512-ELL2,
+// in variable-time.
 //
 // ECVRF_proof_to_hash should be run only on pi_string that is known
 // to have been produced by ECVRF_prove, or from within ECVRF_verify.
@@ -225,7 +226,7 @@ func Verify(pk ed25519.PublicKey, piString, alphaString []byte) (bool, []byte) {
 	if _, err := yString.SetBytes(pk); err != nil {
 		return false, nil
 	}
-	if !yString.IsCanonical() { // Required by RFC 8032 decode semantics.
+	if !yString.IsCanonicalVartime() { // Required by RFC 8032 decode semantics.
 		return false, nil
 	}
 	if _, err := Y.SetCompressedY(&yString); err != nil {
@@ -349,7 +350,7 @@ func decodeProof(piString []byte) (*curve.EdwardsPoint, *scalar.Scalar, *scalar.
 		// Should *NEVER* happen.
 		panic("ecvrf: failed to copy gamma_string: " + err.Error())
 	}
-	if !gammaString.IsCanonical() { // Required by RFC 8032 decode semantics.
+	if !gammaString.IsCanonicalVartime() { // Required by RFC 8032 decode semantics.
 		return nil, nil, nil, fmt.Errorf("ecvrf: non-canonical gamma")
 	}
 	var gamma curve.EdwardsPoint
@@ -369,7 +370,7 @@ func decodeProof(piString []byte) (*curve.EdwardsPoint, *scalar.Scalar, *scalar.
 
 	// 7.  s = string_to_int(s_string)
 	var s scalar.Scalar
-	if !scalar.ScMinimal(piString[48:]) {
+	if !scalar.ScMinimalVartime(piString[48:]) {
 		return nil, nil, nil, fmt.Errorf("ecvrf: non-canonical s")
 	}
 	if _, err := s.SetBytesModOrder(piString[48:]); err != nil {

--- a/primitives/ed25519/extra/ecvrf/ecvrf.go
+++ b/primitives/ed25519/extra/ecvrf/ecvrf.go
@@ -32,8 +32,10 @@
 package ecvrf
 
 import (
+	cryptorand "crypto/rand"
 	"crypto/sha512"
 	"fmt"
+	"io"
 
 	"github.com/oasisprotocol/curve25519-voi/curve"
 	"github.com/oasisprotocol/curve25519-voi/curve/scalar"
@@ -52,25 +54,52 @@ const (
 	twoString   = 0x02
 	threeString = 0x03
 	suiteString = 0x04
+
+	addedRandomnessSize = 32
 )
 
-// The domain separation tag DST, a parameter to the hash-to-curve
-// suite, SHALL be set to "ECVRF_" || h2c_suite_ID_string || suite_string
-var h2cDST = []byte{
-	'E', 'C', 'V', 'R', 'F', '_', // "ECVRF_"
-	'e', 'd', 'w', 'a', 'r', 'd', 's', '2', '5', '5', '1', '9', '_', 'X', 'M', 'D', ':', 'S', 'H', 'A', '-', '5', '1', '2', '_', 'E', 'L', 'L', '2', '_', 'N', 'U', '_', // h2c_suite_ID_string
-	suiteString, // suite_string
-}
+var (
+	// The domain separation tag DST, a parameter to the hash-to-curve
+	// suite, SHALL be set to "ECVRF_" || h2c_suite_ID_string || suite_string
+	h2cDST = []byte{
+		'E', 'C', 'V', 'R', 'F', '_', // "ECVRF_"
+		'e', 'd', 'w', 'a', 'r', 'd', 's', '2', '5', '5', '1', '9', '_', 'X', 'M', 'D', ':', 'S', 'H', 'A', '-', '5', '1', '2', '_', 'E', 'L', 'L', '2', '_', 'N', 'U', '_', // h2c_suite_ID_string
+		suiteString, // suite_string
+	}
+
+	addedRandomnessPadding [1024]byte
+)
 
 // Prove implements ECVRF_prove for the suite ECVRF-EDWARDS25519-SHA512-ELL2.
 func Prove(sk ed25519.PrivateKey, alphaString []byte) []byte {
+	piString, err := doProve(nil, sk, alphaString)
+	if err != nil {
+		panic(err)
+	}
+	return piString
+}
+
+// ProveWithAddedRandomness implements ECVRF_prove for the suite ECVRF-EDWARDS25519-SHA512-ELL2,
+// while including additional randomness to mitigate certain fault injection
+// and side-channel attacks.  If rand is nil, crypto/rand.Reader will be used.
+//
+// Warning: If this is set, proofs (`beta_string`) will be non-deterministic.
+// The VRF output (`pi_string`) is identical to that produced by Prove.
+func ProveWithAddedRandomness(rand io.Reader, sk ed25519.PrivateKey, alphaString []byte) ([]byte, error) {
+	if rand == nil {
+		rand = cryptorand.Reader
+	}
+	return doProve(rand, sk, alphaString)
+}
+
+func doProve(rand io.Reader, sk ed25519.PrivateKey, alphaString []byte) ([]byte, error) {
 	// 1.  Use SK to derive the VRF secret scalar x and the VRF
 	// public key Y = x*B (this derivation depends on the ciphersuite,
 	// as per Section 5.5; these values can be cached, for example,
 	// after key generation, and need not be rederived each time)
 
 	if len(sk) != ed25519.PrivateKeySize {
-		panic("ecvrf: bad private key length")
+		return nil, fmt.Errorf("ecvrf: bad private key length")
 	}
 
 	var (
@@ -84,14 +113,14 @@ func Prove(sk ed25519.PrivateKey, alphaString []byte) []byte {
 	extsk[31] &= 127
 	extsk[31] |= 64
 	if _, err := x.SetBits(extsk[:32]); err != nil {
-		panic("ecvrf: failed to deserialize x scalar: " + err.Error())
+		return nil, fmt.Errorf("ecvrf: failed to deserialize x scalar: %w", err)
 	}
 	Y := sk[32:]
 
 	// 2.  H = ECVRF_hash_to_curve(Y, alpha_string)
 	H, err := hashToCurveH2cSuite(Y, alphaString)
 	if err != nil {
-		panic("ecvrf: failed to hash point to curve: " + err.Error())
+		return nil, fmt.Errorf("ecvrf: failed to hash point to curve: %w", err)
 	}
 
 	// 3.  h_string = point_to_string(H)
@@ -112,11 +141,22 @@ func Prove(sk ed25519.PrivateKey, alphaString []byte) []byte {
 		k      scalar.Scalar
 	)
 	h.Reset()
+	if rand != nil {
+		var entropy [addedRandomnessSize]byte
+		if _, err := io.ReadFull(rand, entropy[:]); err != nil {
+			return nil, fmt.Errorf("ecvrf: failed to read Z: %w", err)
+		}
+		_, _ = h.Write(entropy[:])
+	}
 	_, _ = h.Write(extsk[32:])
+	if rand != nil {
+		padSize := len(addedRandomnessPadding) - (addedRandomnessSize + 32)
+		_, _ = h.Write(addedRandomnessPadding[:padSize])
+	}
 	_, _ = h.Write(hString[:])
 	h.Sum(digest[:0])
 	if _, err = k.SetBytesModOrderWide(digest[:]); err != nil {
-		panic("ecvrf: failed to deserialize k scalar: " + err.Error())
+		return nil, fmt.Errorf("ecvrf: failed to deserialize k scalar: %w", err)
 	}
 
 	// 6.  c = ECVRF_hash_points(H, Gamma, k*B, k*H) (see Section 5.4.3)
@@ -131,18 +171,18 @@ func Prove(sk ed25519.PrivateKey, alphaString []byte) []byte {
 	s.Add(&s, &k)
 
 	// 8.  pi_string = point_to_string(Gamma) || int_to_string(c, n) ||
-	// int_to_string(s, qLen)
+	//                 int_to_string(s, qLen)
 	var piString [ProofSize]byte
 	copy(piString[:32], gammaString[:])
 	if err = c.ToBytes(piString[32:64]); err != nil {
-		panic("ecvrf: failed to serialize c scalar: " + err.Error())
+		return nil, fmt.Errorf("ecvrf: failed to serialize c scalar: %w", err)
 	}
 	if err = s.ToBytes(piString[48:]); err != nil { // c is truncated (128-bits).
-		panic("ecvrf: failed to serialize s scalar: " + err.Error())
+		return nil, fmt.Errorf("ecvrf: failed to serialize s scalar: %w", err)
 	}
 
 	// 9.  Output pi_string
-	return piString[:]
+	return piString[:], nil
 }
 
 // ProofToHash implements ECVRF_proof_to_hash for the suite ECVRF-EDWARDS25519-SHA512-ELL2.

--- a/primitives/ed25519/extra/ecvrf/ecvrf_test.go
+++ b/primitives/ed25519/extra/ecvrf/ecvrf_test.go
@@ -88,6 +88,23 @@ func testIETFVectors(t *testing.T) {
 			t.Fatalf("[%d] beta mismatch (Got: %x)", i, beta)
 		}
 
+		// Test that adding entropy to the signing process produces
+		// different pi, but identical beta.
+		piNonDeterministic, err := ProveWithAddedRandomness(nil, sk, vec.alpha)
+		if err != nil {
+			t.Fatalf("[%d] ProveWithAddedRandomness(): %v", i, err)
+		}
+		if bytes.Equal(piNonDeterministic, pi) {
+			t.Fatalf("[%d] pi (non-determinstic) matched (Got: %x)", i, piNonDeterministic)
+		}
+		ok, beta = Verify(pk, piNonDeterministic, vec.alpha)
+		if !ok {
+			t.Fatalf("[%d] Verify(pi_non_deterministic) failed", i)
+		}
+		if !bytes.Equal(vec.beta, beta) {
+			t.Fatalf("[%d] beta (non-determinstic pi) mismatch (Got: %x)", i, beta)
+		}
+
 		pi[0] ^= 0xa5
 		ok, _ = Verify(pk, pi, vec.alpha)
 		if ok {

--- a/primitives/sr25519/sign.go
+++ b/primitives/sr25519/sign.go
@@ -83,7 +83,7 @@ func (sig *Signature) UnmarshalBinary(data []byte) error {
 	upper[31] &= 127
 
 	// Check that the scalar is encoded in canonical form.
-	if !scalar.ScMinimal(upper[:]) {
+	if !scalar.ScMinimalVartime(upper[:]) {
 		return fmt.Errorf("sr25519: non-canonical signature scalar")
 	}
 	sigScalar, err := scalar.NewFromCanonicalBytes(upper[:])


### PR DESCRIPTION
Like the ed25519 signing variant, this incorporates additional entropy
into the nonce generation step.  The proof output will be
non-deterministic and "different" from other implementations.  The VRF
output will be identical.