### PR TITLE
primitives/ed25519/extra/ecvrf: Change a spooky looking append

### DIFF
--- a/primitives/ed25519/extra/ecvrf/ecvrf.go
+++ b/primitives/ed25519/extra/ecvrf/ecvrf.go
@@ -289,7 +289,9 @@ func gammaToHash(gamma *curve.EdwardsPoint) []byte {
 func hashToCurveH2cSuite(Y, alphaString []byte) (*curve.EdwardsPoint, error) {
 	// 1.  PK_string = point_to_string(Y)
 	// 2.  string_to_hash = PK_string || alpha_string
-	stringToHash := append(Y, alphaString...)
+	stringToHash := make([]byte, 0, len(Y) + len(alphaString))
+	stringToHash = append(stringToHash, Y...)
+	stringToHash = append(stringToHash, alphaString...)
 
 	// 3.  H = encode(string_to_hash)
 	// 4.  Output H


### PR DESCRIPTION
What is there before is correct, but relies on subtleties of how slices
work in Go.  This is more explicit, and more obviously correct.