### PR TITLE
primitives/ed25519/extra/ecvrf: Update to v10 of the draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ does not escape this author.
  * curve: A mid-level API in the spirit of curve25519-dalek.
  * primitives/x25519: A X25519 implementation like `x/crypto/curve25519`.
  * primitives/ed25519: A Ed25519 implementation like `crypto/ed25519`.
- * primitives/ed25519/extra/ecvrf: A implementation of the "Verifiable Random Functions" draft (v09).
+ * primitives/ed25519/extra/ecvrf: A implementation of the "Verifiable Random Functions" draft (v10).
  * primitives/sr25519: A sr25519 implementation like `https://github.com/w3f/schnorrkel`.
  * primitives/merlin: A Merlin transcript implementation.
  * primitives/h2c: A implementation of the "Hashing to Elliptic Curves" draft (v11).

--- a/primitives/ed25519/extra/ecvrf/ecvrf.go
+++ b/primitives/ed25519/extra/ecvrf/ecvrf.go
@@ -371,6 +371,7 @@ func decodeProof(piString []byte) (*curve.EdwardsPoint, *scalar.Scalar, *scalar.
 	}
 
 	// 7.  s = string_to_int(s_string)
+	// 8.  if s >= q output "INVALID" and stop
 	var s scalar.Scalar
 	if !scalar.ScMinimalVartime(piString[48:]) {
 		return nil, nil, nil, fmt.Errorf("ecvrf: non-canonical s")


### PR DESCRIPTION
This is just a documentation update since the scalar canonicity check
added in this version is something that we were doing anyway out of my
sense of paranoia.