### PR TITLE
Catch up to the h2c and ecvrf IETF drafts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ does not escape this author.
  * primitives/ed25519/extra/ecvrf: A implementation of the "Verifiable Random Functions" draft (v10).
  * primitives/sr25519: A sr25519 implementation like `https://github.com/w3f/schnorrkel`.
  * primitives/merlin: A Merlin transcript implementation.
- * primitives/h2c: A implementation of the "Hashing to Elliptic Curves" draft (v14).
+ * primitives/h2c: A implementation of the "Hashing to Elliptic Curves" draft (v16).
 
 #### Ed25519 verification semantics
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ does not escape this author.
  * curve: A mid-level API in the spirit of curve25519-dalek.
  * primitives/x25519: A X25519 implementation like `x/crypto/curve25519`.
  * primitives/ed25519: A Ed25519 implementation like `crypto/ed25519`.
- * primitives/ed25519/extra/ecvrf: A implementation of the "Verifiable Random Functions" draft (v10).
+ * primitives/ed25519/extra/ecvrf: A implementation of the "Verifiable Random Functions" draft (v10, v13).
  * primitives/sr25519: A sr25519 implementation like `https://github.com/w3f/schnorrkel`.
  * primitives/merlin: A Merlin transcript implementation.
  * primitives/h2c: A implementation of the "Hashing to Elliptic Curves" draft (v16).

--- a/primitives/ed25519/extra/ecvrf/ecvrf.go
+++ b/primitives/ed25519/extra/ecvrf/ecvrf.go
@@ -72,7 +72,16 @@ var (
 
 // Prove implements ECVRF_prove for the suite ECVRF-EDWARDS25519-SHA512-ELL2.
 func Prove(sk ed25519.PrivateKey, alphaString []byte) []byte {
-	piString, err := doProve(nil, sk, alphaString)
+	piString, err := doProve(nil, sk, alphaString, false)
+	if err != nil {
+		panic(err)
+	}
+	return piString
+}
+
+// Prove_v10 is Prove but using the v10 (and earlier) semantics.
+func Prove_v10(sk ed25519.PrivateKey, alphaString []byte) []byte {
+	piString, err := doProve(nil, sk, alphaString, true)
 	if err != nil {
 		panic(err)
 	}
@@ -89,10 +98,24 @@ func ProveWithAddedRandomness(rand io.Reader, sk ed25519.PrivateKey, alphaString
 	if rand == nil {
 		rand = cryptorand.Reader
 	}
-	return doProve(rand, sk, alphaString)
+	return doProve(rand, sk, alphaString, false)
 }
 
-func doProve(rand io.Reader, sk ed25519.PrivateKey, alphaString []byte) ([]byte, error) {
+// ProveWithAddedRandomness_v10 is ProveWithAddedRandomness but using the
+// v10 (and earlier) semantics.
+func ProveWithAddedRandomness_v10(rand io.Reader, sk ed25519.PrivateKey, alphaString []byte) ([]byte, error) {
+	if rand == nil {
+		rand = cryptorand.Reader
+	}
+	return doProve(rand, sk, alphaString, true)
+}
+
+func doProve(
+	rand io.Reader,
+	sk ed25519.PrivateKey,
+	alphaString []byte,
+	draftPreV11 bool,
+) ([]byte, error) {
 	// 1.  Use SK to derive the VRF secret scalar x and the VRF
 	// public key Y = x*B (this derivation depends on the ciphersuite,
 	// as per Section 5.5; these values can be cached, for example,
@@ -117,8 +140,8 @@ func doProve(rand io.Reader, sk ed25519.PrivateKey, alphaString []byte) ([]byte,
 	}
 	Y := sk[32:]
 
-	// 2.  H = ECVRF_hash_to_curve(Y, alpha_string)
-	H, err := hashToCurveH2cSuite(Y, alphaString)
+	// 2.  H = ECVRF_encode_to_curve(encode_to_curve_salt, alpha_string)
+	H, err := encodeToCurveH2cSuite(Y, alphaString)
 	if err != nil {
 		return nil, fmt.Errorf("ecvrf: failed to hash point to curve: %w", err)
 	}
@@ -159,11 +182,26 @@ func doProve(rand io.Reader, sk ed25519.PrivateKey, alphaString []byte) ([]byte,
 		return nil, fmt.Errorf("ecvrf: failed to deserialize k scalar: %w", err)
 	}
 
-	// 6.  c = ECVRF_hash_points(H, Gamma, k*B, k*H) (see Section 5.4.3)
-	var kB, kH curve.EdwardsPoint
+	// The challenge generation depends on the version of the IETF draft
+	// because they changed things as of draft v11 to include Y in the hash
+	// input.
+	//
+	// Old: c = ECVRF_hash_points(H, Gamma, k*B, k*H) (see Section 5.4.3)
+	// New: c = ECVRF_challenge_generation(Y, H, Gamma, k*B, k*H)
+	//
+	// Handle this in ECVRF_challenge_generation, since it is a matter
+	// of including Y or not.
+
+	var (
+		kB, kH curve.EdwardsPoint
+		p1     []byte
+	)
 	kB.MulBasepoint(curve.ED25519_BASEPOINT_TABLE, &k)
 	kH.Mul(H, &k)
-	c := hashPoints(&hString, &gammaString, &kB, &kH)
+	if !draftPreV11 {
+		p1 = Y
+	}
+	c := challengeGeneration(p1, &hString, &gammaString, &kB, &kH)
 
 	// 7.  s = (k + c*x) mod q
 	var s scalar.Scalar
@@ -208,9 +246,46 @@ func ProofToHash(piString []byte) ([]byte, error) {
 // The public key is validated such that the "full uniqueness" and
 // "full collision" properties are satisfied.
 func Verify(pk ed25519.PublicKey, piString, alphaString []byte) (bool, []byte) {
-	// 1.  D = ECVRF_decode_proof(pi_string) (see Section 5.4.4)
-	// 2.  If D is "INVALID", output "INVALID" and stop
-	// 3.  (Gamma, c, s) = D
+	return doVerify(pk, piString, alphaString, false)
+}
+
+// Verify_v10 is Verify but using the v10 (and earlier) semantics.
+func Verify_v10(pk ed25519.PublicKey, piString, alphaString []byte) (bool, []byte) {
+	return doVerify(pk, piString, alphaString, true)
+}
+
+func doVerify(
+	pk ed25519.PublicKey,
+	piString []byte,
+	alphaString []byte,
+	draftPreV11 bool,
+) (bool, []byte) {
+	var (
+		Y       curve.EdwardsPoint
+		yString curve.CompressedEdwardsY
+	)
+
+	// 1.   Y = string_to_point(PK_string)
+	if _, err := yString.SetBytes(pk); err != nil {
+		return false, nil
+	}
+	// 2.   If Y is "INVALID", output "INVALID" and stop
+	if !yString.IsCanonicalVartime() { // Required by RFC 8032 decode semantics.
+		return false, nil
+	}
+	if _, err := Y.SetCompressedY(&yString); err != nil {
+		return false, nil
+	}
+	// 3.   If validate_key, run ECVRF_validate_key(Y) (Section 5.4.5); if
+	//      it outputs "INVALID", output "INVALID" and stop
+	if Y.IsSmallOrder() { // Section 5.4.5 ECVRF Validate Key
+		// The IETF draft treats this as optional, but we always have enforced this.
+		return false, nil
+	}
+
+	// 4.   D = ECVRF_decode_proof(pi_string) (see Section 5.4.4)
+	// 5.   If D is "INVALID", output "INVALID" and stop
+	// 6.   (Gamma, c, s) = D
 	gamma, c, s, err := decodeProof(piString)
 	if err != nil {
 		return false, nil
@@ -218,36 +293,21 @@ func Verify(pk ed25519.PublicKey, piString, alphaString []byte) (bool, []byte) {
 	var gammaString curve.CompressedEdwardsY
 	_, _ = gammaString.SetBytes(piString[:32])
 
-	// 4.  H = ECVRF_hash_to_curve(Y, alpha_string)
-	var (
-		Y       curve.EdwardsPoint
-		yString curve.CompressedEdwardsY
-	)
-	if _, err := yString.SetBytes(pk); err != nil {
-		return false, nil
-	}
-	if !yString.IsCanonicalVartime() { // Required by RFC 8032 decode semantics.
-		return false, nil
-	}
-	if _, err := Y.SetCompressedY(&yString); err != nil {
-		return false, nil
-	}
-	if Y.IsSmallOrder() { // Section 5.6.1 ECVRF Validate Key
-		return false, nil
-	}
-	H, err := hashToCurveH2cSuite(yString[:], alphaString)
+	// 7.   H = ECVRF_encode_to_curve(encode_to_curve_salt, alpha_string)
+	//      (see Section 5.4.1)
+	H, err := encodeToCurveH2cSuite(yString[:], alphaString)
 	if err != nil {
 		panic("ecvrf: failed to hash point to curve: " + err.Error())
 	}
 	var hString curve.CompressedEdwardsY
 	hString.SetEdwardsPoint(H)
 
-	// 5.  U = s*B - c*Y
+	// 8.   U = s*B - c*Y
 	var U curve.EdwardsPoint
 	Y.Neg(&Y)
 	U.DoubleScalarMulBasepointVartime(c, &Y, s)
 
-	// 6.  V = s*H - c*Gamma
+	// 9.   V = s*H - c*Gamma
 	var V, negGamma curve.EdwardsPoint
 	negGamma.Neg(gamma)
 	V.MultiscalarMulVartime( // V = s*H + c*(-Gamma)
@@ -255,11 +315,20 @@ func Verify(pk ed25519.PublicKey, piString, alphaString []byte) (bool, []byte) {
 		[]*curve.EdwardsPoint{H, &negGamma},
 	)
 
-	// 7.  c' = ECVRF_hash_points(H, Gamma, U, V) (see Section 5.4.3)
-	cPrime := hashPoints(&hString, &gammaString, &U, &V)
+	// 10.  c' = ECVRF_challenge_generation(Y, H, Gamma, U, V) (see
+	//      Section 5.4.3)
+	//
+	// Note: Old (pre-v11) versions of the draft did not include Y,
+	// and instead did c' = ECVRF_hash_points(H, Gamma, U, V).
+	var p1 []byte
+	if !draftPreV11 {
+		p1 = pk[:]
+	}
+	cPrime := challengeGeneration(p1, &hString, &gammaString, &U, &V)
 
-	// 8.  If c and c' are equal, output ("VALID",
-	//     ECVRF_proof_to_hash(pi_string)); else output "INVALID"
+	// 11.  If c and c' are equal, output ("VALID",
+	//      ECVRF_proof_to_hash(pi_string)); else output "INVALID"
+
 	if c.Equal(cPrime) == 0 {
 		return false, nil
 	}
@@ -286,39 +355,49 @@ func gammaToHash(gamma *curve.EdwardsPoint) []byte {
 	return h.Sum(nil)
 }
 
-func hashToCurveH2cSuite(Y, alphaString []byte) (*curve.EdwardsPoint, error) {
-	// 1.  PK_string = point_to_string(Y)
-	// 2.  string_to_hash = PK_string || alpha_string
-	stringToHash := make([]byte, 0, len(Y)+len(alphaString))
-	stringToHash = append(stringToHash, Y...)
+func encodeToCurveH2cSuite(encodeToCurveSalt, alphaString []byte) (*curve.EdwardsPoint, error) {
+	// For the Edwards25519 curve:
+	// PK_string = point_to_string(Y)
+	// encode_to_curve_salt = PK_string
+
+	// 1. string_to_be_hashed = encode_to_curve_salt || alpha_string
+	stringToHash := make([]byte, 0, len(encodeToCurveSalt)+len(alphaString))
+	stringToHash = append(stringToHash, encodeToCurveSalt...)
 	stringToHash = append(stringToHash, alphaString...)
 
-	// 3.  H = encode(string_to_hash)
-	// 4.  Output H
+	// 2.  H = encode(string_to_hash)
+	// 3.  Output H
 	return h2c.Edwards25519_XMD_SHA512_ELL2_NU(h2cDST, stringToHash)
 }
 
-func hashPoints(p1, p2 *curve.CompressedEdwardsY, p3, p4 *curve.EdwardsPoint) *scalar.Scalar {
-	// 1.  two_string = 0x02 = int_to_string(2, 1), a single octet with
-	//     value 2
-	// 2.  Initialize str = suite_string || two_string
-	// 3.  for PJ in [P1, P2, ... PM]:
-	//       str = str || point_to_string(PJ)
-	// 4.  zero_string = 0x00 = int_to_string(0, 1), a single octet with
-	//     value 0
-	// 5.  str = str || zero_string
-	// 6.  c_string = Hash(str)
+func challengeGeneration(p1 []byte, p2, p3 *curve.CompressedEdwardsY, p4, p5 *curve.EdwardsPoint) *scalar.Scalar {
+	// 1.  challenge_generation_domain_separator_front = 0x02
+	// 2.  Initialize str = suite_string || challenge_generation_domain_separator_front
 	var (
 		tmp    curve.CompressedEdwardsY
 		digest [64]byte
 	)
 	h := sha512.New()
-	_, _ = h.Write([]byte{suiteString, twoString}) // suite_string || two_string
-	_, _ = h.Write(p1[:])                          // point_to_string(P1)
-	_, _ = h.Write(p2[:])                          // point_to_string(P2)
-	_, _ = h.Write(tmp.SetEdwardsPoint(p3)[:])     // point_to_string(P3)
-	_, _ = h.Write(tmp.SetEdwardsPoint(p4)[:])     // point_to_string(P4)
-	_, _ = h.Write([]byte{zeroString})             // zero_string
+	_, _ = h.Write([]byte{suiteString, twoString}) // suite_string || challenge_generation_domain_separator_front
+
+	// 3.  for PJ in [P1, P2, P3, P4, P5]:
+	//       str = str || point_to_string(PJ)
+	if len(p1) > 0 {
+		// This needs to handle both pre-v11 where Y was not included,
+		// and v11 and later, where Y is included.  This branch is the
+		// latter.
+		_, _ = h.Write(p1) // point_to_string(P1)
+	}
+	_, _ = h.Write(p2[:])                      // point_to_string(P2)
+	_, _ = h.Write(p3[:])                      // point_to_string(P3)
+	_, _ = h.Write(tmp.SetEdwardsPoint(p4)[:]) // point_to_string(P3)
+	_, _ = h.Write(tmp.SetEdwardsPoint(p5)[:]) // point_to_string(P4)
+
+	// 4.  challenge_generation_domain_separator_back = 0x00
+	// 5.  str = str || challenge_generation_domain_separator_back
+	_, _ = h.Write([]byte{zeroString}) // challenge_generation_domain_separator_back
+
+	// 6.  c_string = Hash(str)
 	h.Sum(digest[:0])
 
 	// 7.  truncated_c_string = c_string[0]...c_string[n-1]

--- a/primitives/ed25519/extra/ecvrf/ecvrf_test.go
+++ b/primitives/ed25519/extra/ecvrf/ecvrf_test.go
@@ -31,6 +31,7 @@ package ecvrf
 
 import (
 	"bytes"
+	"io"
 	"testing"
 
 	"github.com/oasisprotocol/curve25519-voi/internal/testhelpers"
@@ -48,13 +49,16 @@ func testIETFVectors(t *testing.T) {
 		alpha []byte
 		pi    []byte
 		beta  []byte
+		v10   bool
 	}{
+		// Old (v10 and prior) semantics
 		{
 			sk:    testhelpers.MustUnhex(t, "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60"),
 			pk:    testhelpers.MustUnhex(t, "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"),
 			alpha: []byte{},
 			pi:    testhelpers.MustUnhex(t, "7d9c633ffeee27349264cf5c667579fc583b4bda63ab71d001f89c10003ab46f25898f6bd7d4ed4c75f0282b0f7bb9d0e61b387b76db60b3cbf34bf09109ccb33fab742a8bddc0c8ba3caf5c0b75bb04"),
 			beta:  testhelpers.MustUnhex(t, "9d574bf9b8302ec0fc1e21c3ec5368269527b87b462ce36dab2d14ccf80c53cccf6758f058c5b1c856b116388152bbe509ee3b9ecfe63d93c3b4346c1fbc6c54"),
+			v10:   true,
 		},
 		{
 			sk:    testhelpers.MustUnhex(t, "4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb"),
@@ -62,6 +66,7 @@ func testIETFVectors(t *testing.T) {
 			alpha: []byte{0x72},
 			pi:    testhelpers.MustUnhex(t, "47b327393ff2dd81336f8a2ef10339112401253b3c714eeda879f12c509072ef9bf1a234f833f72d8fff36075fd9b836da28b5569e74caa418bae7ef521f2ddd35f5727d271ecc70b4a83c1fc8ebc40c"),
 			beta:  testhelpers.MustUnhex(t, "38561d6b77b71d30eb97a062168ae12b667ce5c28caccdf76bc88e093e4635987cd96814ce55b4689b3dd2947f80e59aac7b7675f8083865b46c89b2ce9cc735"),
+			v10:   true,
 		},
 		{
 			sk:    testhelpers.MustUnhex(t, "c5aa8df43f9f837bedb7442f31dcb7b166d38535076f094b85ce3a2e0b4458f7"),
@@ -69,18 +74,57 @@ func testIETFVectors(t *testing.T) {
 			alpha: []byte{0xaf, 0x82},
 			pi:    testhelpers.MustUnhex(t, "926e895d308f5e328e7aa159c06eddbe56d06846abf5d98c2512235eaa57fdce6187befa109606682503b3a1424f0f729ca0418099fbd86a48093e6a8de26307b8d93e02da927e6dd5b73c8f119aee0f"),
 			beta:  testhelpers.MustUnhex(t, "121b7f9b9aaaa29099fc04a94ba52784d44eac976dd1a3cca458733be5cd090a7b5fbd148444f17f8daf1fb55cb04b1ae85a626e30a54b4b0f8abf4a43314a58"),
+			v10:   true,
+		},
+		// New (v11 and latter) semantics
+		{
+			sk:    testhelpers.MustUnhex(t, "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60"),
+			pk:    testhelpers.MustUnhex(t, "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a"),
+			alpha: []byte{},
+			pi:    testhelpers.MustUnhex(t, "7d9c633ffeee27349264cf5c667579fc583b4bda63ab71d001f89c10003ab46f14adf9a3cd8b8412d9038531e865c341cafa73589b023d14311c331a9ad15ff2fb37831e00f0acaa6d73bc9997b06501"),
+			beta:  testhelpers.MustUnhex(t, "9d574bf9b8302ec0fc1e21c3ec5368269527b87b462ce36dab2d14ccf80c53cccf6758f058c5b1c856b116388152bbe509ee3b9ecfe63d93c3b4346c1fbc6c54"),
+		},
+		{
+			sk:    testhelpers.MustUnhex(t, "4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb"),
+			pk:    testhelpers.MustUnhex(t, "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c"),
+			alpha: []byte{0x72},
+			pi:    testhelpers.MustUnhex(t, "47b327393ff2dd81336f8a2ef10339112401253b3c714eeda879f12c509072ef055b48372bb82efbdce8e10c8cb9a2f9d60e93908f93df1623ad78a86a028d6bc064dbfc75a6a57379ef855dc6733801"),
+			beta:  testhelpers.MustUnhex(t, "38561d6b77b71d30eb97a062168ae12b667ce5c28caccdf76bc88e093e4635987cd96814ce55b4689b3dd2947f80e59aac7b7675f8083865b46c89b2ce9cc735"),
+		},
+		{
+			sk:    testhelpers.MustUnhex(t, "c5aa8df43f9f837bedb7442f31dcb7b166d38535076f094b85ce3a2e0b4458f7"),
+			pk:    testhelpers.MustUnhex(t, "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025"),
+			alpha: []byte{0xaf, 0x82},
+			pi:    testhelpers.MustUnhex(t, "926e895d308f5e328e7aa159c06eddbe56d06846abf5d98c2512235eaa57fdce35b46edfc655bc828d44ad09d1150f31374e7ef73027e14760d42e77341fe05467bb286cc2c9d7fde29120a0b2320d04"),
+			beta:  testhelpers.MustUnhex(t, "121b7f9b9aaaa29099fc04a94ba52784d44eac976dd1a3cca458733be5cd090a7b5fbd148444f17f8daf1fb55cb04b1ae85a626e30a54b4b0f8abf4a43314a58"),
 		},
 	}
 	for i, vec := range testVectors {
 		sk := ed25519.NewKeyFromSeed(vec.sk)
 		pk := sk.Public().(ed25519.PublicKey)
 
-		pi := Prove(sk, vec.alpha)
+		var (
+			proveFn     func(ed25519.PrivateKey, []byte) []byte
+			verifyFn    func(ed25519.PublicKey, []byte, []byte) (bool, []byte)
+			proveRandFn func(io.Reader, ed25519.PrivateKey, []byte) ([]byte, error)
+		)
+		switch vec.v10 {
+		case false:
+			proveFn = Prove
+			verifyFn = Verify
+			proveRandFn = ProveWithAddedRandomness
+		case true:
+			proveFn = Prove_v10
+			verifyFn = Verify_v10
+			proveRandFn = ProveWithAddedRandomness_v10
+		}
+
+		pi := proveFn(sk, vec.alpha)
 		if !bytes.Equal(vec.pi, pi) {
 			t.Fatalf("[%d] pi mismatch (Got: %x)", i, pi)
 		}
 
-		ok, beta := Verify(pk, pi, vec.alpha)
+		ok, beta := verifyFn(pk, pi, vec.alpha)
 		if !ok {
 			t.Fatalf("[%d] Verify() failed", i)
 		}
@@ -90,14 +134,14 @@ func testIETFVectors(t *testing.T) {
 
 		// Test that adding entropy to the signing process produces
 		// different pi, but identical beta.
-		piNonDeterministic, err := ProveWithAddedRandomness(nil, sk, vec.alpha)
+		piNonDeterministic, err := proveRandFn(nil, sk, vec.alpha)
 		if err != nil {
 			t.Fatalf("[%d] ProveWithAddedRandomness(): %v", i, err)
 		}
 		if bytes.Equal(piNonDeterministic, pi) {
 			t.Fatalf("[%d] pi (non-determinstic) matched (Got: %x)", i, piNonDeterministic)
 		}
-		ok, beta = Verify(pk, piNonDeterministic, vec.alpha)
+		ok, beta = verifyFn(pk, piNonDeterministic, vec.alpha)
 		if !ok {
 			t.Fatalf("[%d] Verify(pi_non_deterministic) failed", i)
 		}
@@ -106,7 +150,7 @@ func testIETFVectors(t *testing.T) {
 		}
 
 		pi[0] ^= 0xa5
-		ok, _ = Verify(pk, pi, vec.alpha)
+		ok, _ = verifyFn(pk, pi, vec.alpha)
 		if ok {
 			t.Fatalf("[%d] bad pi, Verify() passed", i)
 		}


### PR DESCRIPTION
There are no functional changes in the newer versions of the h2c draft for the suites we care about.

The ECVRF IETF draft broke proof backward compatibility as of v11, and we based the implementation off v10.  As there are systems in production that use the v10 style proofs, backward compatibility APIs are needed.  If people blindly bump the import, they will see undesirable behavior (old proofs will fail to verify etc), but surely people don't blindly bump dependencies right?