### PR TITLE
build: Support the `wasm` target

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,14 @@ the appropriate special cases to make `math/bits.Mul64`/`math/bits.Add64`
 perform well.
 
  * 64-bit: `amd64`, `arm64`, `ppc64le`, `ppc64`, `s390x`
- * 32-bit: `386`, `arm`, `mips`, `mipsle`, `mips64`, `mips64le`, `riscv64`, `loong64`
+ * 32-bit: `386`, `arm`, `mips`, `mipsle`, `wasm`, `mips64`, `mips64le`, `riscv64`, `loong64`
  * Unsupported: Everything else.
- * Will never support: `wasm`
+
+**WARNING**: As a concession to the target's growing popularity, the
+`wasm` target is supported using the 32-bit backend, however the
+WebAssembly specification does not mandate that any opcodes are
+constant time, making it difficult to provide assurances related to
+timing side-channels.
 
 The lack of a generic "just use 32-bit" fallback can be blamed on
 the Go developers rejecting [adding build tags for bit-width][3].

--- a/curve/constants_u32.go
+++ b/curve/constants_u32.go
@@ -29,7 +29,7 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//go:build (386 || arm || mips || mipsle || mips64le || mips64 || riscv64 || loong64 || force32bit) && !force64bit
+//go:build (386 || arm || mips || mipsle || wasm || mips64le || mips64 || riscv64 || loong64 || force32bit) && !force64bit
 
 package curve
 

--- a/curve/constants_u32_test.go
+++ b/curve/constants_u32_test.go
@@ -29,7 +29,7 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//go:build (386 || arm || mips || mipsle || mips64le || mips64 || riscv64 || loong64 || force32bit) && !force64bit
+//go:build (386 || arm || mips || mipsle || wasm || mips64le || mips64 || riscv64 || loong64 || force32bit) && !force64bit
 
 package curve
 

--- a/curve/scalar/constants_u32.go
+++ b/curve/scalar/constants_u32.go
@@ -29,7 +29,7 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//go:build (386 || arm || mips || mipsle || mips64le || mips64 || riscv64 || loong64 || force32bit) && !force64bit
+//go:build (386 || arm || mips || mipsle || wasm || mips64le || mips64 || riscv64 || loong64 || force32bit) && !force64bit
 
 package scalar
 

--- a/curve/scalar/scalar_u32.go
+++ b/curve/scalar/scalar_u32.go
@@ -29,7 +29,7 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//go:build (386 || arm || mips || mipsle || mips64le || mips64 || riscv64 || loong64 || force32bit) && !force64bit
+//go:build (386 || arm || mips || mipsle || wasm || mips64le || mips64 || riscv64 || loong64 || force32bit) && !force64bit
 
 package scalar
 

--- a/curve/scalar/scalar_u32_test.go
+++ b/curve/scalar/scalar_u32_test.go
@@ -29,7 +29,7 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//go:build (386 || arm || mips || mipsle || mips64le || mips64 || riscv64 || loong64 || force32bit) && !force64bit
+//go:build (386 || arm || mips || mipsle || wasm || mips64le || mips64 || riscv64 || loong64 || force32bit) && !force64bit
 
 package scalar
 

--- a/internal/elligator/constants_u32.go
+++ b/internal/elligator/constants_u32.go
@@ -27,7 +27,7 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//go:build (386 || arm || mips || mipsle || mips64le || mips64 || riscv64 || loong64 || force32bit) && !force64bit
+//go:build (386 || arm || mips || mipsle || wasm || mips64le || mips64 || riscv64 || loong64 || force32bit) && !force64bit
 
 package elligator
 

--- a/internal/field/constants_u32.go
+++ b/internal/field/constants_u32.go
@@ -28,7 +28,7 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//go:build (386 || arm || mips || mipsle || mips64le || mips64 || riscv64 || loong64 || force32bit) && !force64bit
+//go:build (386 || arm || mips || mipsle || wasm || mips64le || mips64 || riscv64 || loong64 || force32bit) && !force64bit
 
 package field
 

--- a/internal/field/field_u32.go
+++ b/internal/field/field_u32.go
@@ -29,7 +29,7 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//go:build (386 || arm || mips || mipsle || mips64le || mips64 || riscv64 || loong64 || force32bit) && !force64bit
+//go:build (386 || arm || mips || mipsle || wasm || mips64le || mips64 || riscv64 || loong64 || force32bit) && !force64bit
 
 package field
 

--- a/primitives/ed25519/ed25519_test.go
+++ b/primitives/ed25519/ed25519_test.go
@@ -50,6 +50,7 @@ func TestStdLib(t *testing.T) {
 	t.Run("SignVerify", testSignVerify)
 	t.Run("SignVerify/Hashed", testSignVerifyHashed)
 	t.Run("SignVerify/AddedRandomness", testSignVerifyAddedRandomness)
+	t.Run("SignVerify/SelfVerify", testSignVerifySelfVerify)
 	t.Run("CryptoSigner", testCryptoSigner)
 	t.Run("CryptoSigner/Hashed", testCryptoSignerHashed)
 	t.Run("Equal", testEqual)
@@ -117,6 +118,25 @@ func testSignVerifyAddedRandomness(t *testing.T) {
 	sig2 := Sign(private, msg)
 	if bytes.Equal(sig, sig2) {
 		t.Errorf("standard signature matches entropy added signature")
+	}
+}
+
+func testSignVerifySelfVerify(t *testing.T) {
+	var zero zeroreader.ZeroReader
+	public, private, _ := GenerateKey(zero)
+
+	msg := []byte("Of course, if you wish, you can spend them fighting for a lost cause, but you know that you've lost.")
+
+	opts := &Options{
+		SelfVerify: true,
+	}
+	sig, err := private.Sign(nil, msg, opts)
+	if err != nil {
+		t.Fatalf("failed to sign with self-verify: %v", err)
+	}
+
+	if !Verify(public, msg, sig) {
+		t.Errorf("valid signature rejected")
 	}
 }
 


### PR DESCRIPTION
I'm not sure if I should do this or not.  Part of me thinks this may be ok, since this will be no worse than other libraries out there that people are using.  The other part of me thinks that being principled and waiting till WebAssembly fixes their crap is also reasonable.